### PR TITLE
Fix lipoic acid metabolism

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #123** (CUSTOM-CI)
+- **PR #126** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:
- Adds new metabolite cpd14953_c0: Protein N6-(octanoyl)lysine
- Adds new metabolite cpd24682_c0: 4Fe4S iron-sulfur cluster
- Adds new metabolite cpd16584_c0: Protein N6-(dihydrolipoyl)lysine
- Adds new metabolite cpd14954_c0: Protein N6-(lipoyl)lysine
- Adds new gene TK37_RS12780 (sufT)
- Adds new gene TK37_RS16620 (lipA)
- Replaces cpd00449_c0 (dihydrolipoamide) with cpd16584_c0 (Protein N6-(dihydrolipoyl)lysine) in rxn01872_c0, rxn01871_c0, rxn01925_c0, rxn01241_c0, rxn09498_c0, rxn06586_c0, and rxn06335_c0 (all of the reactions that cpd00449_c0 is currently present in)
- Replaces cpd00213_c0 (lipoamide) with cpd14954_c0 (Protein N6-(lipoyl)lysine) in rxn01241_c0, rxn02342_c0, rxn02376_c0, rxn07431_c0, rxn07433_c0, rxn07435_c0, and rxn09499_c0 (all of the reactions that cpd00213_c0 is currently present in)
- Adds new reaction octanoyl_xfer: cpd11470_c0 -> cpd14953_c0 + cpd11493_c0, GPR: TK37_RS16625 (lipB)
  - the ID for this reaction is not a ModelSEED reaction ID; see below for explanation
- Creates a new reaction lipoyl_synth: cpd14953_c0 + cpd24682_c0 + 2 cpd00017_c0 + 2 cpd11620_c0 + 8 cpd00067_c0 -> cpd16584_c0 + cpd27144_c0 + 4 cpd10515_c0 + 2 cpd00239_c0 + 2 cpd03091_c0 + 2 cpd00060_c0 + 2 cpd11621_c0, GPR: TK37_RS12780 and TK37_RS16620 (sufT and lipA)
  - the ID for this reaction is not a ModelSEED reaction ID because it does not match any of the several versions of this reaction on ModelSEED (all of them have at least one error)
- Removes cpd00213_c0, cpd00449_c0, cpd27144_c0, cpd27713_c0, and rxn23336_c0 from the model

In #103, I proposed to have the lipoic acid biosynthesis reaction produce cpd27144_c0 (Gcv-H), because rxn23336_c0 is already in the model and produces “octanoylated Gcv-H” (cpd27713_c0) from Gcv-H (cpd27144_c0) and octanoyl-ACP (cpd11470_c0). I did not do that in this pull request because I realized that the new lipoic acid biosynthesis reaction would still be flagged by the dilution test because the only two reactions that Gcv-H would participate in would be this new reaction and rxn23336_c0. It doesn’t have a biosynthesis reaction of its own because it’s not really a metabolite — it’s an enzyme. Furthermore, it’s not even clear if new lipoic acid is synthesized on Gcv-H in _Alteromonas macleoidii_; that’s how humans and yeast do it, but _E. coli_ produces it on the E2 subunit of the pyruvate dehydrogenase complex (sources: [1](https://doi.org/10.1073/pnas.1805862115), [2](https://doi.org/10.1016/j.chembiol.2003.11.016)). It turns out that ModelSEED has compounds called “Protein N6-(octanoyl)lysine“ (cpd14953), “Protein N6-(lipoyl)lysine” (cpd14954), and “(Protein N6-(dihydrolipoyl)lysine” (cpd16584), which seem like better metabolites to use than octanoylated Gcv-H (cpd27713), lipoamide (cpd00213), and dihydrolipoamide (cpd00449), since they more clearly convey that the metabolite they represent is covalently bound to a protein and it could be one of several proteins (the “amide” in “lipoamide” and “dihydrolipoamide” is kind of a shorthand way to indicate that lipoyl groups are bound to the enzymes that use them as cofactors via amide bonds to lysine residues in the enzymes. While it is an established convention, I find it unnecessarily confusing.).

**I hereby confirm that I have:**
- [x] Tested my code on my own computer for running the model
- [x] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
