### PR TITLE
Fix iron-sulfur cluster biosynthesis

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #123** (CUSTOM-CI)
+- **PR #128** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

As proposed in #104:
- Adds new gene TK37_RS12785, name: sufE
- Adds new gene TK37_RS12755, name: sufB
- Adds new gene TK37_RS12760, name: sufC
- Adds new gene TK37_RS12765, name: sufD
- Adds a new reaction to represent iron-sulfur cluster biosynthesis:
  - 4 cpd00084_c0 + 4 cpd10515_c0 + 3 cpd00982_c0 + cpd00002_c0 + cpd00001_c0 -> cpd24682_c0 + 4 cpd00035_c0 + 3 cpd00015_c0 + 10 cpd00067_c0 + cpd00008_c0 + cpd00009_c0
  - GPR: TK37_RS12750 and TK37_RS12785 and TK37_RS12755 and TK37_RS12760 and TK37_RS12765
  - In #104, I only used 7 protons (cpd00067_c0), but while putting together this PR, I realized that it needs 10 protons to be mass- and charge-balanced
- Removes rxn45692_c0, cpd28205_c0, and cpd14548_c0 from the model

Also adds cpd24682_c0: 4Fe4S iron-sulfur cluster, even though that wasn’t proposed in #104 because it’s added by #126. This is definitely not best practice, but I made sure that all of the metadata is exactly the same, and it means that I can make this PR now and don’t have to wait until after #126 is merged.

**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [x] Tested my code on my own computer for running the model
- [x] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
