### PR TITLE
Fix incorrect names for cpd00239_c0 and cpd00239_e0

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #123** (CUSTOM-CI)
+- **PR #131** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

As proposed in #105, renames cpd00239_c0 and cpd00239_e0 from "H2S [c0]" and "H2S [e0]" to "Bisulfide (HS-) [c0]" and "Bisulfide (HS-) [e0]", respectively

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists