### PR TITLE
Standardizing names of fatty acid metabolites

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #123** (CUSTOM-CI)
+- **PR #134** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

I’ve been looking around for potential issues with fatty acid metabolism and noticed a number of inconsistencies with how metabolites are named. I feel like removing these inconsistencies will make it easier to identify existing mistakes and avoid future mistakes, so this pull request:
- Renames cpd01741_c0 from “ddca” to “Dodecanoate”
- Standardizes the names of ACP conjugates by
  - Renaming cpd11492_c0 from “Malonyl-acyl-carrierprotein-” to “Malonyl-ACP”,
  - Renaming cpd36635_c0 from “Malonyl-acp-methyl-ester” to “Malonyl-ACP-methyl-ester”,
  - Renaming cpd11486_c0 from “3-Oxohexanoyl-[acp]” to “3-Oxohexanoyl-ACP”,
  - Renaming cpd21087_c0 from “Pimelyl-[acyl-carrier protein]” to “Pimeloyl-ACP”,
  - Renaming cpd11490_c0 from “3-oxooctanoyl-acp” to “3-Oxooctanoyl-ACP”,
  - Renaming cpd11487_c0 from “3-oxodecanoyl-acp” to “3-Oxodecanoyl-ACP”,
  - Renaming cpd11489_c0 from “3-oxododecanoyl-acp” to “3-Oxododecanoyl-ACP”,
  - Renaming cpd11491_c0 from “3-oxotetradecanoyl-acp” to “3-Oxotetradecanoyl-ACP”,
  - Renaming cpd11484_c0 from “HMA” to “3-Hydroxymyristoyl-ACP”,
  - Renaming cpd11476_c0 from “hexadecanoyl-acp” to “Hexadecanoyl-ACP”, and
  - Renaming cpd11485_c0 from “3-oxohexadecanoyl-acp” to “3-Oxohexadecanoyl-ACP”.
- Standardizes the names of fatty acid methyl esters by
  - Renaming cpd27180_c0 from “Glutaryl-ACP-methyl-esters” to “Glutaryl-ACP-methyl-ester”,
  - Renaming cpd22028_c0 from “3-Ketopimeloyl-ACP-methyl-esters” to “3-Ketopimeloyl-ACP-methyl-ester”, and
  - Renaming cpd22065_c0 from “3-hydroxypimeloyl-ACP-methyl-esters” to “3-Hydroxypimeloyl-ACP-methyl-ester”.
- Ensures that the names of all unsaturated fatty acid metabolites clearly indicate where the double bonds are by
  - Renaming cpd27020_c0 from “Enoylglutaryl-ACP-methyl-esters” to “(2E)-Enoylglutaryl-ACP-methyl-ester”,
  - Renaming cpd27021_c0 from “Enoylpimeloyl-ACP-methyl-esters” to “(2E)-Enoylpimeloyl-ACP-methyl-ester”,
  - Renaming cpd15298_c0 from “tetradecenoate” to “7-Tetradecenoate”,
  - Renaming cpd15294_c0 from “Tetradecenoyl-ACP” to “7-Tetradecenoyl-ACP”,
  - Renaming cpd15237_c0 from “hexadecenoate” to “9-Hexadecenoate”,
  - Renaming cpd15239_c0 from “Hexadecenoyl-ACP” to “9-Hexadecenoyl-ACP”, and
  - Renaming cpd11825_c0 from “Octadecenoyl-ACP” to “11-Octadecenoyl-ACP”.

I left off the [c0] suffixes from the names above just to make it easier to read, but I did actually include those in the new names for all the metabolites in the model.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
