### PR TITLE
Allow production of dATP and dCTP

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #157** (CUSTOM-CI)
+- **PR #159** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request

- Makes rxn05289_c0 reversible, as it is on [ModelSEED](https://modelseed.org/biochem/reactions/rxn05289)

and makes no other changes to the model. The model is currently incapable of sustaining flux through several thioredoxin-dependent redox reactions, including those responsible for producing dATP and dCTP (see #158), because the redox reaction between thioredoxin and NADP(H) is inexplicably irreversible in the thioredoxin-oxidizing direction:

rxn05289_c0 NADP [c0] + trdrd [c0] --> NADPH [c0] + H+ [c0] + trdox [c0]

Making this reaction reversible allows the model to produce all four deoxyribonucleotides (it can currently only produce two, see #158), which are required for biomass production.

**I hereby confirm that I have:**
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists