### PR TITLE
Fix/change 3hb to cpd00797

### DIFF
--- a/test/test_files/kbase_phenotype_set.tsv
+++ b/test/test_files/kbase_phenotype_set.tsv
@@ -5,7 +5,7 @@ none	hgsco:narrative_1740349496319	mbm.media	cpd00029	1
 none	hgsco:narrative_1740349496319	l1.media	cpd00029	1
 none	hgsco:narrative_1740349496319	mbm.media	cpd00139	0
 none	hgsco:narrative_1740349496319	mbm.media	cpd00737	1
-none	hgsco:narrative_1740349496319	mbm.media	cpd29193	1
+none	hgsco:narrative_1740349496319	mbm.media	cpd00797	1
 none	hgsco:narrative_1740349496319	mbm.media	cpd00098	0
 none	hgsco:narrative_1740349496319	mbm.media	cpd03727	0
 none	hgsco:narrative_1740349496319	mbm.media	cpd00035	1

--- a/test/test_files/known_growth_phenotypes.tsv
+++ b/test/test_files/known_growth_phenotypes.tsv
@@ -5,7 +5,7 @@ mbm	Acetate	cpd00029	ac	Yes
 l1	Acetate	cpd00029	ac	Yes	
 mbm	Glycolate	cpd00139	glyclt	No	
 mbm	Homarine	cpd00737		Unsure	Not sure about metabolite ID. Called gynesine in ModelSEED.
-mbm	3-hydroxybutyrate	cpd29193		Yes	
+mbm	3-hydroxybutyrate	cpd00797		Yes	
 mbm	Choline	cpd00098	chol	No	
 mbm	Ectoine	cpd03727	ectoine	No	
 mbm	Alanine	cpd00035	ala__L	Unsure	Maybe. Only grows on first transfer from rich media but not subsequent; maybe using storage. Used the ModelSEED ID for L-alanine.

--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #167** (CUSTOM-CI)
+- **PR #169** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:
<!-- Try to be as clear as possible in providing a summary of the work and reference the corresponding issue.
Is it fixing/adding something in the model?
Is it an additional test/function/dataset? 
e.g. This PR improves/fixes # by ...
-->
This PR does not change the model file, it updates the ModelSEED ID for 3-hydroxybutyrate in `known_growth_phenotypes.tsv`. Instead of using cpd29193, it now uses cpd00797. cpd00797 is in the model and is named "3-hydroxybutanoate" which is another name for 3-hydroxybutyrate. And the model doesn't actually seem to have a metabolite with the ID cpd29193_c0 or cpd29193_e0.

**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
