### PR TITLE
feat: add probable transport reactions for glycerol-3-phosphate, tyro…

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #169** (CUSTOM-CI)
+- **PR #171** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request

- Adds cpd00080_e0 to represent extracellular glycerol-3-phosphate
- Adds cpd00069_e0 to represent extracellular tyrosine
- Adds rxn08642_c0: Glycerol-3-phosphate [e0] + Phosphate [c0] -> Glycerol-3-phosphate [c0] + Phosphate [e0]
- Adds rxn05301_c0: L-Tyrosine [e0] + H+ [e0] -> L-Tyrosine [c0] + H+ [c0]
- Adds rxn05242_c0: L-Valine [e0] + Na+ [e0] -> L-Valine [c0] + Na+ [c0]
- Adds rxn05669_c0: L-Valine [e0] + H+ [e0] -> H+ + L-Valine

The model cannot grow in media with glycerol-3-phosphate, tyrosine, or valine as the carbon sole source, but real Alteromonas macleodii apparently can. The model does not currently have an extracellular metabolite for either glycerol-3-phosphate or tyrosine, and the only transport reaction it has for valine is ATP-dependent (rxn05168_c0), which it can’t use if valine is the only carbon source. The model may have other problems with the metabolism of these three compounds, but it definitely won’t be able to grow in media where any of these are the carbon sources if it can’t even get them into the cytosolic compartment.

I couldn’t find any traces of any proteins predicted to be glycerol-3-phosphate transporters in the GFF file. Most papers about glycerol-3-phosphate transporters (e.g. [this one](https://doi.org/10.1016/j.bbagen.2011.07.006)) are specifically talking about glcyerol-3-phosphate:phosphate antiporters, and [TCDB](https://www.tcdb.org/progs/?tool=substrate#/systems/type:chebi-id:15978) doesn’t seem to annotate any other kinds of glycerol-3-phosphate transporters, so I figured it wasn’t unreasonable to assume that that’s also how Alteromonas macleodii imports glycerol-3-phosphate.

[These](https://doi.org/10.1016/S0923-2508(01)01197-4) [papers](https://www.microbiologyresearch.org/content/journal/micro/10.1099/00221287-146-8-1775) say that most bacterial amino acid transporters do symport of amino acids and protons or sodium ions, so I suspect that Alteromonas macleodii is probably capable of proton and/or sodium symport with tyrosine and/or valine. ModelSEED already had IDs for both sodium and proton symport with valine, but only had IDs for tyrosine:proton symport, which is why I did not also add a tyrosine:sodium symport reaction.

While all of these transport reactions I’m adding here are nominally reversible, if you make these reactions reversible in GSMMs, you can predict unrealistic loop fluxes that move sodium ions or protons or phosphate or whatever out of the cell with one symport reaction and bring them back in with another, bypassing the ATP-dependent sodium/proton/phosphate export reactions that establish the concentration gradients that actually drive these reactions into the cell in real life, so I’ve made them irreversible in the model to avoid this issue.

**I hereby confirm that I have:**
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists