### PR TITLE
Add exchange reactions for tyrosine and glycerol-3-phosphate

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #171** (CUSTOM-CI)
+- **PR #172** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request

- Adds EX_cpd00069_e0
- Adds EX_cpd00080_e0

Just realized I forgot to add exchange reactions for the new extracellular tyrosine and glycerol-3-phosphate metabolites that I added in #171

**I hereby confirm that I have:**
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists