### PR TITLE
Replace glycolate redox reaction

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #174** (CUSTOM-CI)
+- **PR #176** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:
- Removes rxn00979_c0
- Adds rxn00333: O2 + Glycolate => H2O2 + Glyoxalate, GPR: TK37_RS19095, E.C. 1.1.3.15

I noticed that [Daniel Sher previously said to remove rxn00979 from the model and instead use rxn00333 to oxidize glycolate to glyoxalate](https://docs.google.com/spreadsheets/d/1ruaXCqI6Yr-xf0Gd4jsZEsdeSVD6Hbuo_njNRzQqPRw/edit?gid=0#gid=0), but I did not notice that before adding rxn00979 to the model in #160, so this PR corrects that oversight. While the GFF file doesn’t annotate TK37_RS19095 with E.C. 1.1.3.15, the eggNOG file annotated WP_039227034.1 with that E.C. number, and the GFF file says that that’s the protein_id for TK37_RS19095.

**I hereby confirm that I have:**
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists