### PR TITLE
Add back unintentionally removed glycolaldehyde oxidase reaction

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #176** (CUSTOM-CI)
+- **PR #178** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request
- Adds rxn00979_c0 (which was initially added in #160 and then removed in #172)
- Removes rxn00512_c0

Realized that I accidentally removed rxn00979_c0 (redox of glycolaldehyde and glycolate) in #176 when I meant to remove rxn00512_c0 (redox of glycolate and glyoxalate)

**I hereby confirm that I have:**
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
