### PR TITLE
Add plausible uptake and catabolism pathways for DHPS

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #176** (CUSTOM-CI)
+- **PR #178** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.

--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #178** (CUSTOM-CI)
+- **PR #179** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

Note that I branched this off of #178 instead of dev

This pull request

- Adds cpd23538_e0: (S)-2,3-dihydroxypropane-1-sulfonate [e0]
- Adds EX_cpd23538_e0: cpd23538_e0 <=>
- Adds cpd23538_c0: (S)-2,3-dihydroxypropane-1-sulfonate [c0]
- Adds cpd23538_trans: (S)-2,3-dihydroxypropane-1-sulfonate [e0] + Na<sup>+</sup> [e0] <=> (S)-2,3-dihydroxypropane-1-sulfonate [c0] + Na<sup>+</sup> [c0]
- Adds cpd23539_c0: 2-oxo-3-hydroxy-propane-1-sulfonate [c0]
- Adds rxn22083_c0: (S)-2,3-dihydroxypropane-1-sulfonate + NADP<sup>+</sup> <=> 2-oxo-3-hydroxy-propane-1-sulfonate + NADPH + H<sup>+</sup>
- Adds cpd20923_c0: (R)-2,3-Dihydroxypropane-1-sulfonate [c0]
- Adds rxn22084_c0: 2-oxo-3-hydroxy-propane-1-sulfonate + NADH + H<sup>+</sup> <=> (R)-2,3-Dihydroxypropane-1-sulfonate + NAD<sup>+</sup>
- Adds cpd08367_c0: (2R)-3-Sulfolactate [c0]
- Adds rxn16387_c0: (R)-2,3-Dihydroxypropane-1-sulfonate + 2 NAD<sup>+</sup> + H<sub>2</sub>O <=> 2 NADH + 3 H<sup>+</sup> + (2R)-3-Sulfolactate
- Adds rxn04934_c0: NAD + (2R)-3-Sulfolactate <=> NADH + H<sup>+</sup> + 3-Sulfopyruvate
- Adds rxn07450_c0: L-Cysteate + H<sub>2</sub>O => NH<sub>3</sub> + Pyruvate + Sulfite

These changes allow the model to use (S)-2,3-dihydroxypropane-1-sulfonate (DHPS) as a carbon source. Currently, the model lacks an uptake pathway for DHPS, and doesn’t even have a cytosolic metabolite for DHPS; the only reaction involved in DHPS catabolism that the model already has is 

rxn01757_c0: 2-Oxoglutarate [c0] + L-Cysteate [c0] <=> L-Glutamate [c0] + 3-Sulfopyruvate [c0]
GPR: TK37_RS18640 and TK37_RS13800

But this is the only reaction that involves 3-sulfopyruvate (cpd03285) or cysteate (cpd00395), so it’s a dead-end. I cannot find any hint of any genes known or suspected or predicted to catalyze any other steps of any known DHPS catabolism pathway (sources: [1](https://www.sciencedirect.com/science/article/pii/S0160412021004542),[2](https://www.pnas.org/doi/full/10.1073/pnas.1413137112),[3](https://pubs.rsc.org/en/content/articlehtml/2024/sc/d4sc05114a),[4](https://www.microbiologyresearch.org/content/journal/micro/10.1099/mic.0.037580-0)) in the GFF file or the eggNOG results or any published paper; I suspect that the only reason that rxn01757_c0 is already in the model is because it’s just associated with some aminotransferases that recognize a variety of substrates.

![image](https://github.com/user-attachments/assets/6abf1d89-2f3c-46f3-890f-1e81aeb2e10e)

Since we know that Alteromonas macleodii can use DHPS as its primary carbon source, but seem to have no information whatsoever about which catabolic pathway it uses, I’m mostly arbitrarily adding the middle pathway shown in the figure above, since the aminotransferase step is already in the model. Even though I have no solid evidence that Alteromonas macleodii uses that particular pathway, the model shouldn’t be too far off of reality as long as real A. macleodii use one of the other currently known catabolic pathways, since they all involve the same first and last steps, produce very similar end products (pyruvate vs acetyl-CoA, sulfite vs sulfate), and use similar cofactors (NAD(H) vs NADP(H)). Let me know if there’s any data that I’m not aware of that suggests that A. macleodii uses a different pathway than the one I added here and I can edit this PR to reflect that.

The most I could find out about DHPS transporters was [this paper](https://www.microbiologyresearch.org/content/journal/micro/10.1099/mic.0.037580-0), that “hypothesize[d] that a tripartite ATP-independent transport system (TRAP-T)” is responsible, and all of the TRAP-Ts that [TCDB mentions on their summary page for TRAP-T](https://www.tcdb.org/search/result.php?tc=2.a.56) symport their substrates with protons or sodium ions. ModelSEED doesn’t have any transport reactions for DHPS, so I have somewhat arbitrarily decided to create a DHPS:sodium symport reaction just so that the model has a transport reaction for it. It’ll be easy enough to edit it if new information comes to light about exactly how A. macleodii transports DHPS, and a number of other metabolites already have sodium symport reactions, so adding one more is unlikely to cause (new) problems.

**I hereby confirm that I have:**
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
