### PR TITLE
Renaming miscellaneous metabolites

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #176** (CUSTOM-CI)
+- **PR #180** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request

- Renames cpd00508_c0 from “3MOP [c0]” to “3-methyl-2-oxopentoate [c0]”
- Renames cpd00200_c0 from “4MOP [c0]” to “4-methyl-2-oxopentoate [c0]”
- Renames cpd00443_c0 from “ABEE [c0]” to “4-aminobenzoate [c0]”
- Renames cpd08210_c0 from “ADC [c0]” to “4-amino-4-deoxychorismate [c0]”
- Renames cpd21088_c0 from "Pimelyl-[acyl-carrier protein] methyl ester [c0]" to "Pimeloyl-ACP methyl ester [c0]"
- Renames cpd00149_e0 from "" (empty string) to "Co2+ [e0]"
- Renames cpd00209_e0 from "Nitrate" to "Nitrate [e0]"

Since most of the discrepancies between predicted and experimentally observed growth seem to be resolved, and Helen said she’s already working on figuring out the problem with valine, which I suspect is likely related to the problems with leucine and isoleucine, I figured that it was now an appropriate time for me to start working through the list of lower-priority fixes I’ve been accumulating.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
