### PR TITLE
Remove duplicate thioredoxin metabolites & reactions

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #176** (CUSTOM-CI)
+- **PR #181** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request

- Renames cpd11420_c0 from “trdox” to “Oxidized thioredoxin [c0]”
- Renames cpd11421_c0 from “trdrd” to “Reduced thioredoxin [c0]”
- Removes rxn17275_c0 for being a duplicate of rxn05239_c0
- Removes rxn27318_c0 for being a duplicate of rxn05289_c0
- Removes cpd27735_c0 (Ox-Thioredoxin) for being a duplicate of cpd11420_c0
- Removes cpd28060_c0 (Red-Thioredoxin) for being a duplicate of cpd11421_c0

rxn17275_c0: 3-phosphoadenylylsulfate + Red-Thioredoxin --> Adenosine 3-5-bisphosphate + H<sup>+</sup> + Sulfite + Ox-Thioredoxin
rxn05239_c0 3-phosphoadenylylsulfate + Reduced thioredoxin --> Adenosine 3-5-bisphosphate + H<sup>+</sup> + Sulfite + Oxidized thioredoxin

rxn27318_c0: NADP<sup>+</sup> + Red-Thioredoxin <=> NADPH + H<sup>+</sup> + Ox-Thioredoxin
rxn05289_c0 NADP<sup>+</sup> + Reduced thioredoxin <=> NADPH + H<sup>+</sup> + Oxidized thioredoxin

I came across these while working on #159

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists