### PR TITLE
Fix GPR of thiazol_synth reaction

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #176** (CUSTOM-CI)
+- **PR #184** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request

- Changes the GPR of thiazol_synth from 'TK37_RS12770 and TK37_RS10915 and TK37_RS10910' to 'TK37_RS12770 and TK37_RS10915 and TK37_RS10910 and TK37_RS10920' (adds TK37_RS10920)

and makes no other changes to the model

While working on #182, it occurred to me that I should check to see if removing those reactions would leave any genes in the model associated with no reactions, and I realized that TK37_RS10920 had been left without any associated reactions at some point. Since it was still associated with a reaction in the version of model.xml on the main branch, I was able to determine that TK37_RS10920 became isolated by the changes made in #144, when I was condensing several existing but disconnected reactions into a single reaction, and forgot to include all of the genes associated with the separate reactions in the GPR of the condensed reaction (thiazol_synth).


**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists