### PR TITLE
Revisiting duplicate lysine biosynthesis reactions

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #176** (CUSTOM-CI)
+- **PR #186** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request

- Adds cpd21488_c0: (2S,4S)-4-Hydroxy-2,3,4,5-tetrahydrodipicolinate [c0]
- Adds rxn40037_c0: Pyruvate + L-Aspartate4-semialdehyde --> H2O + H+ + (2S,4S)-4-Hydroxy-2,3,4,5-tetrahydrodipicolinate, GPR: TK37_RS08515 and TK37_RS16235
- Adds rxn39452_c0: NADPH + H+ + (2S,4S)-4-Hydroxy-2,3,4,5-tetrahydrodipicolinate <=> H2O + NADP+ + tetrahydrodipicolinate
- Removes rxn01644_c0 for being a duplicate of rxn40037_c0
- Removes rxn02929_c0 for being a duplicate of rxn39452_c0
- Removes cpd02120_c0: dihydropicolinate [0]

In #142, I removed rxn40037_c0, rxn39452_c0, and cpd21488_c0 for being duplicates of rxn01644_c0, rxn02929_c0, and cpd02120_c0, but I have since noticed that the E.C. number for rxn01644 (4.2.1.52) [was retired in 2012](https://www.genome.jp/dbget-bin/www_bget?enzyme+4.2.1.52) in favor of the E.C. number for rxn40037 (4.3.3.7), so I now think that we should keep the other set of duplicates.

Also note that, before #142, the GPR of rxn40037_c0 was just `TK37_RS08515`, but in this PR, I’m instead setting it to `TK37_RS08515 and TK37_RS16235`, because TK37_RS08515 is annotated with E.C. 4.3.3.7 in the GFF file (the same as TK37_RS16235), and to avoid leaving TK37_RS08515 not associated with any reactions, since it is currently only associated with rxn01644_c0, which this PR removes.

**I hereby confirm that I have:**
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists