### PR TITLE
Remove cpd11836_c0 and rxn07981_c0

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #176** (CUSTOM-CI)
+- **PR #190** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request

- Removes rxn07981_c0 for being a duplicate of rxn05239_c0
- Removes cpd11836_c0 for being a duplicate of cpd11478_c0

rxn07981_c0 is the only reaction that cpd11836_c0 ((R)-3-Hydroxyacyl-[acyl-carrier protein]) can participate in:

rxn07981_c0: (R)-3-Hydroxyacyl-[acyl-carrier protein] <=> H2O+ (2E)-Butenoyl-ACP

it is clearly a duplicate of rxn05239_c0, which instead uses cpd11478_c0 ((3R)-3-Hydroxybutanoyl-ACP), which actually participates in other reactions:

rxn05329_c0 (3R)-3-Hydroxybutanoyl-ACP [c0] <=> H2O [c0] + (2E)-Butenoyl-ACP [c0]

I came across these while working on #134 and #145

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists