### PR TITLE
Remove Questionably Real Duplicate Thiamin Biosynthesis Reaction

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #190** (CUSTOM-CI)
+- **PR #192** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request

- Removes rxn08131_c0 for being a less accurate duplicate of rxn20643_c0

and makes no other changes to the model.

Both reactions are associated with only one gene, thiC (TK37_RS10930), which the GFF file annotates with E.C. 4.1.99.17. However, only rxn20643_c0 is annotated with E.C. 4.1.99.17; rxn08131_c0 isn’t annotated with any E.C. code, even on the ModelSEED website; I have no idea where that reaction comes from, because everything else I can find about thiC describes it as catalyzing the reaction shown in rxn20643_c0.

rxn08131_c0:
H2O [c0] + NAD [c0] + AIR [c0] <=> NADH [c0] + 2.0 Formate [c0] + 4.0 H+ [c0] + 4-Amino-5-phosphomethyl-2-methylpyrimidine [c0]

rxn20643_c0:
S-Adenosyl-L-methionine [c0] + AIR [c0] --> Formate [c0] + L-Methionine [c0] + H+ [c0] + CO [c0] + 4-Amino-5-phosphomethyl-2-methylpyrimidine [c0] + 5'-Deoxyadenosine [c0]
this is E.C. 4.1.99.17

My best guess is that rxn08131_c0 might’ve been added by a gap filler at some point, since, until I added a catabolic pathway for 5’-deoxyadenosine in #130, rxn20643_c0 would’ve been a dead-end, but the only pathway that consumes 4-Amino-5-phosphomethyl-2-methylpyrimidine in the model is thiamine biosynthesis, which was blocked until I fixed it in #144, so who knows where rxn08131_c0 came from. As far as I can tell, there is no evidence to support the existence of rxn08131_c0, and removing it won’t prevent fluxes through any other reactions.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists