### PR TITLE
Fix last step of octadecanoyl-ACP biosynthesis

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #190** (CUSTOM-CI)
+- **PR #194** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request

- Replaces NADPH (cpd00005_c0) with NADH (cpd00004_c0) in rxn08937_c0
- Replaces NADP<sup>+</sup> (cpd00006_c0) with NAD<sup>+</sup> (cpd00003_c0) in rxn08937_c0
- Changes the E.C. number associated with rxn08937_c0 from 1.3.1.104 to 1.3.1.9
- Changes the ID of rxn08937_c0 to rxn05464_c0

When I added rxn08397_c0 to the model in #145, I apparently failed to notice that every other 2-enoyl-ACP reductase reaction that was already in the model used NADH and not NADPH, and since they’re all catalyzed by the same gene (TK37_RS07910), they should all use the same one.


**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists