### PR TITLE
Curate E.C. numbers for fatty acid synthesis reactions

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #190** (CUSTOM-CI)
+- **PR #195** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request changes the E.C. numbers that the following reactions are annotated with:

reaction ID | reaction equation | current E.C. numbers | new E.C. numbers
---|---|---|---
rxn05349_c0 | Acetyl-CoA + ACP <=> CoA + Acetyl-ACP | 2.3.1.86, 2.3.1.180, 2.3.1.85, 2.3.1.179, 2.3.1.38 | 2.3.1.38
rxn05465_c0 | H+ + Malonyl-CoA + ACP <=> CoA + Malonyl-ACP | 2.3.1.85, 2.3.1.39, 2.3.1.86 | 2.3.1.39
rxn05347_c0 | Malonyl-ACP + Acetyl-ACP --> CO2 + Acetoacetyl-ACP + ACP | 2.3.1.86, 2.3.1.180, 2.3.1.85, 2.3.1.179, 2.3.1.41 | 2.3.1.41, 2.3.1.179
rxn05339_c0 | NADP + (3R)-3-Hydroxybutanoyl-ACP <=> NADPH + Acetoacetyl-ACP | 2.3.1.85, 1.1.1.100, 2.3.1.86 | 1.1.1.100
rxn05329_c0 | (3R)-3-Hydroxybutanoyl-ACP <=> H2O + (2E)-Butenoyl-ACP | 4.2.1.58 | 4.2.1.59
rxn05322_c0 | NADH + 2.0 H+ + (2E)-Butenoyl-ACP --> NAD + Butyryl-ACP | 2.3.1.86, 1.3.1.9 | 1.3.1.9
rxn05346_c0 | Butyryl-ACP + Malonyl-ACP --> CO2 + 3-Oxohexanoyl-ACP + ACP | 2.3.1.86, 2.3.1.180, 2.3.1.85, 2.3.1.179, 2.3.1.41 | 2.3.1.41, 2.3.1.179
rxn05337_c0 | NADP + (3R)-3-Hydroxyhexanoyl-ACP <=> NADPH + 3-Oxohexanoyl-ACP | 2.3.1.85, 1.1.1.100, 2.3.1.86 | 1.1.1.100
rxn05330_c0 | (3R)-3-Hydroxyhexanoyl-ACP <=> H2O + (2E)-Hexenoyl-ACP | 4.2.1.59, 2.3.1.85, 4.2.1.58, 2.3.1.86 | 4.2.1.59
rxn05326_c0 | NADH + H+ + (2E)-Hexenoyl-ACP --> NAD + Hexanoyl-ACP | 2.3.1.86, 1.3.1.9 | 1.3.1.9
rxn05350_c0 | H+ + Hexanoyl-ACP + Malonyl-ACP --> CO2 + 3-Oxooctanoyl-ACP + ACP | 2.3.1.86, 2.3.1.180, 2.3.1.85, 2.3.1.179, 2.3.1.41 | 2.3.1.41, 2.3.1.179
rxn05341_c0 | NADP + (3R)-3-Hydroxyoctanoyl-ACP <=> NADPH + H+ + 3-Oxooctanoyl-ACP | 2.3.1.85, 1.1.1.100, 2.3.1.86 | 1.1.1.100
rxn05334_c0 | (3R)-3-Hydroxyoctanoyl-ACP <=> H2O + (2E)-Octenoyl-ACP | 2.3.1.86, 4.2.1.61, 2.3.1.85, 4.2.1.59, 4.2.1.58 | 4.2.1.59
rxn05325_c0 | NADH + H+ + (2E)-Octenoyl-ACP --> NAD + Octanoyl-ACP | 2.3.1.86, 1.3.1.9 | 1.3.1.9
rxn05343_c0 | Octanoyl-ACP + Malonyl-ACP --> CO2 + 3-Oxodecanoyl-ACP + ACP | 2.3.1.86, 2.3.1.180, 2.3.1.85, 2.3.1.179, 2.3.1.41 | 2.3.1.41, 2.3.1.179
rxn05338_c0 | NADP + (3R)-3-Hydroxydecanoyl-ACP <=> NADPH + H+ + 3-Oxodecanoyl-ACP | 2.3.1.85, 1.1.1.100, 2.3.1.86 | 1.1.1.100
rxn05333_c0 | (3R)-3-Hydroxydecanoyl-ACP <=> H2O + H+ + (2E)-Decenoyl-ACP | 2.3.1.86, 4.2.1.61, 4.2.1.60, 2.3.1.85, 4.2.1.58 | 4.2.1.59
rxn05327_c0 | NADH + 2.0 H+ + (2E)-Decenoyl-ACP --> NAD + Decanoyl-ACP | 2.3.1.86, 1.3.1.9 | 1.3.1.9
rxn05348_c0 | Decanoyl-ACP + Malonyl-ACP --> CO2 + 3-Oxododecanoyl-ACP + ACP | 2.3.1.86, 2.3.1.180, 2.3.1.85, 2.3.1.179, 2.3.1.41 | 2.3.1.41, 2.3.1.179
rxn05340_c0 | NADP + (3R)-3-Hydroxydodecanoyl-ACP <=> NADPH + 3-Oxododecanoyl-ACP | 2.3.1.85, 1.1.1.100, 2.3.1.86 | 1.1.1.100
rxn05331_c0 | (3R)-3-Hydroxydodecanoyl-ACP <=> H2O + (2E)-Dodecenoyl-ACP | 2.3.1.86, 4.2.1.61, 4.2.1.60, 2.3.1.85, 4.2.1.59, 4.2.1.58 | 4.2.1.59
rxn05324_c0 | NADH + 2.0 H+ + (2E)-Dodecenoyl-ACP --> NAD + Dodecanoyl-ACP | 2.3.1.86, 1.3.1.9 | 1.3.1.9
rxn05345_c0 | Dodecanoyl-ACP + Malonyl-ACP --> CO2 + 3-Oxotetradecanoyl-ACP + ACP | 2.3.1.86, 2.3.1.180, 2.3.1.85, 2.3.1.179, 2.3.1.41 | 2.3.1.41, 2.3.1.179
rxn05342_c0 | NADP + (3R)-3-Hydroxytetradecanoyl-ACP <=> NADPH + 3-Oxotetradecanoyl-ACP | 2.3.1.85, 1.1.1.100, 2.3.1.86 | 1.1.1.100
rxn05335_c0 | (3R)-3-Hydroxytetradecanoyl-ACP <=> H2O + (2E)-Tetradecenoyl-ACP | 4.2.1.59, 2.3.1.85, 2.3.1.86, 4.2.1.61 | 4.2.1.59
rxn05323_c0 | NADH + 2.0 H+ + (2E)-Tetradecenoyl-ACP --> NAD + Tetradecanoyl-ACP | 2.3.1.86, 1.3.1.9 | 1.3.1.9
rxn05344_c0 | Tetradecanoyl-ACP + Malonyl-ACP --> CO2 + 3-Oxohexadecanoyl-ACP + ACP | 2.3.1.86, 2.3.1.180, 2.3.1.85, 2.3.1.179, 2.3.1.41 | 2.3.1.41, 2.3.1.179
rxn05336_c0 | NADP + (3R)-3-Hydroxyhexadecanoyl-ACP <=> NADPH + 3-Oxohexadecanoyl-ACP | 2.3.1.85, 1.1.1.100, 2.3.1.86 | 1.1.1.100
rxn05332_c0 | (3R)-3-Hydroxyhexadecanoyl-ACP <=> H2O + (2E)-Hexadecenoyl-ACP | 2.3.1.85, 2.3.1.86, 4.2.1.61 | 4.2.1.59
rxn05328_c0 | NADH + H+ + (2E)-Hexadecenoyl-ACP --> NAD + Hexadecanoyl-ACP | 2.3.1.86, 1.3.1.9 | 1.3.1.9
rxn05460_c0 | Hexadecanoyl-ACP + Malonyl-ACP --> CO2 + ACP + 3-Oxooctadecanoyl-ACP | 2.3.1.0 | 2.3.1.41, 2.3.1.179
rxn05461_c0 | NADPH + H+ + 3-Oxooctadecanoyl-ACP <=> NADP + (3R)-3-Hydroxyoctadecanoyl-ACP | 1.1.1.0 | 1.1.1.100
rxn05462_c0 | (3R)-3-Hydroxyoctadecanoyl-ACP <=> H2O + (2E)-Octadecenoyl-ACP | 4.2.1.0 | 4.2.1.59

To summarize, I’m
- Removing [2.3.1.85](https://www.genome.jp/entry/2.3.1.85) and [2.3.1.86](https://www.genome.jp/entry/2.3.1.86) from all reactions, since those are for multifunctional fatty acid synthases, which are primarily found in eukaryotes, while most bacteria instead use a separate enzyme for each step, and the few bacteria known to have multifunctional fatty acid synthases do not seem to be close relatives of Alteromonas ([source](https://www.sciencedirect.com/science/article/pii/S0076687909046175?casa_token=FmCjoR9YwpUAAAAA:bK4VU3sjZSakojhj6kvmEQIYB2udjSN_zpI5GHLBoY_l4xRW7UpiMGIX_bI0SCma_XNL6ZE3lYQ#bb0083)).
- Removing [2.3.1.180](https://www.genome.jp/entry/2.3.1.180) from reactions that add a malonyl-ACP to an acyl-ACP because this E.C. number is specifically for adding malonyl-ACP to an acyl-CoA
- Removing [4.2.1.58](https://www.genome.jp/entry/4.2.1.58), [4.2.1.60](https://www.genome.jp/entry/4.2.1.60), and [4.2.1.61](https://www.genome.jp/entry/4.2.1.61) from all reactions because they were retired and merged into [4.2.1.59](https://www.genome.jp/entry/4.2.1.59) (and replacing them with 4.2.1.59 if it wasn’t already there)
- Replacing all the E.C. numbers that end in 0 (which is the same as ending with an x or a hyphen, i.e. leaving the last digit blank/unspecified) with complete E.C. numbers appropriate for those reactions (e.g. replacing 1.1.1.0 with [1.1.1.100](https://www.genome.jp/entry/1.1.1.100))

I’ve left rxn08397_c0 out of this because I’m handling it in #194

**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists