### PR TITLE
Make branched-chain CoA dehydrogenase reactions reversible

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #190** (CUSTOM-CI)
+- **PR #198** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:
<!-- Try to be as clear as possible in providing a summary of the work and reference the corresponding issue.
Is it fixing/adding something in the model?
Is it an additional test/function/dataset? 
e.g. This PR improves/fixes # by ...
-->

As I proposed in #188:

- Makes rxn01924_c0 reversible
- Makes rxn02270_c0 reversible
- Makes rxn02866_c0 reversible

All three are reversible on ModelSEED's website, and they were irreversible in the direction that blocked catabolism of the branched-chain amino acids (valine, leucine, and isoleucine)

**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists