### PR TITLE
Renaming more metabolites

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #203** (CUSTOM-CI)
+- **PR #205** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request changes the names of the following metabolites:

metabolite ID | current name | new name
---|---|---
cpd00193_c0 | APS [c0] | 5’-Adenylyl sulfate [c0]
cpd00461_c0 | Oxopent-4-enoate [c0] | 2-Hydroxy-2,4-pentadienoate [c0]
cpd03847_e0 | Tetradecanoic acid [e0] | Tetradecanoate [c0]
cpd03847_c0 | Tetradecanoic acid [c0] | Tetradecanoate [c0]
cpd15298_c0 | 7-Tetradecenoate | (7Z)-Tetradecenoate [c0]
cpd15237_c0 | 9-Hexadecenoate [c0] | (9Z)-Hexadecenoate [c0]
cpd15269_c0 | octadecenoate [c0] | (11Z)-Octadecenoate [c0]
cpd00204_e0 | CO | CO [e0]
cpd00342_c0 | N-acetylornithine | N-acetylornithine [c0]
cpd15366_c0 | (3R,5Z)-3-Hydroxydodecenoyl-ACP | (3R,5Z)-3-Hydroxydodecenoyl-ACP [c0]
cpd14954_c0 | Protein N6-(lipoyl)lysine | Protein N6-(lipoyl)lysine [c0]
cpd00123_e0 | 3-Methyl-2-oxobutanoate | 3-Methyl-2-oxobutanoate [e0]
cpd00200_c0 | 4-methyl-2-oxopentoate [c0] | 4-Methyl-2-oxopentanoate [c0]
cpd11497_c0 | 4-methyl-3-hydroxy-hexanoyl-ACP [c0] | (3R)-3-hydroxy-4-methylhexanoyl-ACP [c0]
cpd11498_c0 | 4-methyl-trans-hex-2-enoyl-ACP [c0] | (2E)-4-methylhexenoyl-ACP [c0]
cpd11522_c0 | 5-methyl-3-hydroxy-hexanoyl-ACP [c0] | (3R)-3-hydroxy-5-methylhexanoyl-ACP [c0]
cpd11523_c0 | 5-methyl-trans-hex-2-enoyl-ACP [c0] | (2E)-5-methylhexenoyl-ACP [c0]
cpd11501_c0 | 6-methyl-3-hydroxy-octanoyl-ACP [c0] | (3R)-3-hydroxy-6-methyloctanoyl-ACP [c0]
cpd11502_c0 | 6-methyl-trans-oct-2-enoyl-ACP [c0] | (2E)-6-methyloctenoyl-ACP [c0]
cpd11526_c0 | 7-methyl-3-hydroxy-octanoyl-ACP [c0] | (3R)-3-hydroxy-7-methyloctanoyl-ACP [c0]
cpd11527_c0 | 7-methyl-trans-oct-2-enoyl-ACP [c0] | (2E)-7-methyloctenoyl-ACP [c0]
cpd11505_c0 | 8-methyl-3-hydroxy-decanoyl-ACP [c0] | (3R)-3-hydroxy-8-methyldecanoyl-ACP [c0]
cpd11506_c0 | 8-methyl-trans-dec-2-enoyl-ACP [c0] | (2E)-8-methyldecenoyl-ACP [c0]
cpd11530_c0 | 9-methyl-3-hydroxy-decanoyl-ACP [c0] | (3R)-3-hydroxy-9-methyldecanoyl-ACP [c0]
cpd11531_c0 | 9-methyl-trans-dec-2-enoyl-ACP [c0] | (2E)-9-methyldecenoyl-ACP [c0]
cpd11509_c0 | 10-methyl-3-hydroxy-dodecanoyl-ACP [c0] | (3R)-3-hydroxy-10-methyldodecanoyl-ACP [c0]
cpd11510_c0 | 10-methyl-trans-dodec-2-enoyl-ACP [c0] | (2E)-10-methyldodecenoyl-ACP [c0]
cpd11534_c0 | 11-methyl-3-hydroxy-dodecanoyl-ACP [c0] | (3R)-3-hydroxy-11-methyldodecanoyl-ACP [c0]
cpd11535_c0 | 11-methyl-trans-dodec-2-enoyl-ACP [c0] | (2E)-11-methyldodecenoyl-ACP [c0]
cpd11513_c0 | 12-methyl-3-hydroxy-tetra-decanoyl-ACP [c0] | (3R)-3-hydroxy-12-methyltetradecanoyl-ACP [c0]
cpd11514_c0 | 12-methyl-trans-tetra-dec-2-enoyl-ACP [c0] | (2E)-12-methyltetradecenoyl-ACP [c0]
cpd11538_c0 | 13-methyl-3-hydroxy-tetra-decanoyl-ACP [c0] | (3R)-3-hydroxy-13-methyltetradecanoyl-ACP [c0]
cpd11539_c0 | 13-methyl-trans-tetra-dec-2-enoyl-ACP [c0] | (2E)-13-methyltetradecenoyl-ACP [c0]
cpd11517_c0 | 14-methyl-3-hydroxy-hexa-decanoyl-ACP [c0] | (3R)-3-hydroxy-14-methylhexadecanoyl-ACP [c0]
cpd11518_c0 | 14-methyl-trans-hexa-dec-2-enoyl-ACP [c0] | (2E)-14-methylhexadecenoyl-ACP [c0]
cpd11542_c0 | 15-methyl-3-hydroxy-hexa-decanoyl-ACP [c0] | (3R)-3-hydroxy-15-methylhexadecanoyl-ACP [c0]
cpd11543_c0 | 15-methyl-trans-hexa-dec-2-enoyl-ACP | (2E)-15-methylhexadecenoyl-ACP [c0]

This is mostly making the names of branched-chain acyl-ACPs follow the same format as the rest of the acyl-ACPs, but I’m also adding the compartment suffixes ([c0] or [e0]) to all the names that didn’t already have it (those are mostly metabolites that we added to the model recently) and correcting a few typos that I spotted in the names of metabolites that I renamed earlier.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists