### PR TITLE
Remove duplicate folate biosynthesis reaction

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #203** (CUSTOM-CI)
+- **PR #206** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request
- Removes rxn02200_c0 for being a less-accurate duplicate of rxn02503_c0 + rxn02201_c0
- Changes the GPR of rxn02201_c0 from `TK37_RS16725 or (TK37_RS08325 and TK37_RS18960)` to `TK37_RS16725`

rxn02200_c0 turns 6-hydroxymethyl-7,8-dihydropterin and 4-aminobenzoate into dihydropteroate in a single step, while rxn02503_c0 and rxn02201_c0 accomplish the same thing in two steps, but also split ATP into AMP and pyrophosphate (PPi) in the process.

rxn02200_c0:
4-aminobenzoate (cpd00443_c0) + 6-hydroxymethyl dihydropterin (cpd00954_c0) <=> H2O (cpd00001_c0) + Dihydropteroate (cpd00683_c0)
GPR: TK37_RS16725 or (TK37_RS08325 and TK37_RS18960)
E.C.: [2.5.1.15](https://www.kegg.jp/entry/2.5.1.15)

rxn02503_c0:
ATP (cpd00002_c0) + 6-hydroxymethyl dihydropterin (cpd00954_c0) --> AMP (cpd00018_c0) + H+ (cpd00067_c0) + 2-Amino-4-hydroxy-6-hydroxymethyl-7-8-dihydropteridinediphosphate (cpd02920_c0)
GPR: TK37_RS08325 and TK37_RS18960
E.C.: [2.7.6.3](https://www.kegg.jp/entry/R03503)

rxn02201_c0:
4-aminobenzoate (cpd00443_c0) + 2-Amino-4-hydroxy-6-hydroxymethyl-7-8-dihydropteridinediphosphate (cpd02920_c0) --> PPi (cpd00012_c0) + H+ (cpd00067_c0) + Dihydropteroate (cpd00683_c0)
GPR: TK37_RS16725 or (TK37_RS08325 and TK37_RS18960)
E.C.: [2.5.1.15](https://www.kegg.jp/entry/2.5.1.15)

[As far as I can tell](https://onlinelibrary.wiley.com/doi/epdf/10.1002/bies.10114), there is no enzyme capable of converting 6-hydroxymethyl-7,8-dihydropterin to dihydropteroate in a single step; there are some organisms with multifunctional enzymes that can catalyze both rxn02503_c0 and rxn02201_c0, but the overall reaction would still consume ATP and produce AMP and pyrophosphate, which is not what rxn02200_c0 shows. So I’m removing rxn02200_c0 for misrepresenting the amount of ATP required for de novo folate biosynthesis.

TK37_RS08325 and TK37_RS18960 are both annotated with E.C. [2.7.6.3](https://www.kegg.jp/entry/R03503) in the GFF file, which definitely corresponds to rxn02503_c0 and not rxn02201_c0, so I’m removing them from the GPR of rxn02201_c0.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists