### PR TITLE
Fix octanoyl_xfer reaction

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #203** (CUSTOM-CI)
+- **PR #207** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request

- Replaces cpd14954_c0 (Protein-N6-(lipoyl)lysine) with cpd14953_c0 (Protein N6-(octanoyl)lysine) in reaction octanoyl_xfer

and makes no other changes to the model.

I just realized that I accidentally made the octanoyl_xfer reaction that I added to the model in #126 produce Protein-N6-(lipoyl)lysine (cpd14954_c0) instead of Protein N6-(octanoyl)lysine (cpd14953_c0), which made the lipoyl_synth reaction I also added in #126 a dead-end, since nothing could produce Protein-N6-(octanoyl)lysine.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists