### PR TITLE
Remove unnecessary duplicate dead-end ubiquinone biosynthesis reaction and intermediate

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #203** (CUSTOM-CI)
+- **PR #208** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Removes rxn08353_c0 for being a duplicate of rxn11946_c0
- Removes cpd15360_c0 for being a duplicate of cpd03449_c0

rxn08353_c0 is the only reaction that cpd15360_c0 participates in, so they’re both dead-ends. Ubiquinol (cpd15561_c0), the product of rxn08353_c0, can already be made from ubiqunone (cpd15560_c0), which can be produced by a series of reactions that ends with rxn11964_c0:

rxn08353_c0:
S-Adenosyl-L-methionine (cpd00017_c0) + 2-Octaprenyl-3-methyl-5-hydroxy-6-methoxy-1,4-benzoquinol (cpd15360_c0) <=> S-Adenosyl-homocysteine (cpd00019_c0) + H+ (cpd00067_c0) + Ubiquinol-8 (cpd15561_c0)

rxn11964_c0:
S-Adenosyl-L-methionine (cpd00017_c0) + 2-Octaprenyl-3-methyl-5-hydroxy-6-methoxy-1,4-benzoquinone (cpd03449_c0) <=> S-Adenosyl-homocysteine (cpd00019_c0) + H+ (cpd00067_c0) + Ubiquinone-8 (cpd15560_c0

Strictly speaking, cpd15360_c0 and cpd03449_c0 are two different chemicals, so they’re not really duplicates, but I believe that all quinones and quinols are relatively easy to interconvert (hence why ubiquinone/ubiquinol and menaquinone/menaquinol etc. are cofactors that tons of different organisms use as cofactors in redox reactions), so I don’t think we’d really be missing much by only having one version of the ubiquinone/ubiquinol biosynthesis pathway that uses the quinone versions of all of the intermediates. See also #139, where I removed rxn09039_c0, cpd15359_c0, and cpd15361_c0 for similar reasons.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists