### PR TITLE
Correct mass imbalance in rxn00979_c0

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #203** (CUSTOM-CI)
+- **PR #209** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Adds cpd00139_c0 (glycolate) to rxn00979_c0 with a coefficient of 1

and makes no other changes to the model.

I just realized that I left glycolate out of rxn00979_c0 when I was adding it back to the model in #178, which left rxn00979_c0 unbalanced:

Before this PR:
H2O [c0] + NAD [c0] + Glycolaldehyde [c0] <=> NADH [c0] + 2.0 H+ [c0]

After this PR:
H2O [c0] + NAD [c0] + Glycolaldehyde [c0] <=> NADH [c0] + 2.0 H+ [c0] + Glycolate [c0]

In case you’re curious, I came across this mistake as well as the one in #207 by looking through the list of reactions that are still flagged as dead-ends by MACAW.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists