### PR TITLE
Fix Fatty Acid Oxidation Dead-End

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #203** (CUSTOM-CI)
+- **PR #210** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request

- Makes rxn00872_c0 reversible
- Makes rxn02167_c0 reversible

These two reactions represent two of the final steps in the fatty acid oxidation pathway, but they are irreversibly oriented against the direction of fatty acid oxidation, rendering the entire fatty acid oxidation pathway (dozens of reactions) dead-ends at butyryl-CoA. As far as I can tell, [both](https://doi.org/10.1021/bi051048y) reactions [should](https://journals.asm.org/doi/full/10.1128/jb.01621-07) be [reversible](https://doi.org/10.1016/S0968-0896(02)00333-4), as shown in ModelSEED and all other databases I can find them in (e.g. KEGG, Uniprot).

rxn00872_c0: FAD + Butyryl-CoA <-> Crotonyl-CoA + FADH2
rxn02167_c0: (S)-3-Hydroxybutyryl-CoA <-> H2O + Crotonyl-CoA

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists