### PR TITLE
Removing duplicate reactions involving glucose anomers

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #203** (CUSTOM-CI)
+- **PR #211** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request

- Removes rxn15249_c0 for being a duplicate of rxn00216_c0
- Removes rxn15230_c0 for being a duplicate of rxn00816_c0
- Removes rxn01108_c0 for being a duplicate of rxn04945_c0
- Removes rxn01109_c0 for being a duplicate of rxn04945_c0
- Removes rxn01171_c0
- Removes cpd19001_c0 for being a duplicate of cpd00027_c0
- Removes cpd00190_c0 for being a duplicate of cpd00027_c0
- Removes cpd19006_c0 for being a duplicate of cpd00079_c0

Several reactions in the model that involve glucose exist in multiple copies, because the model has multiple glucose metabolites, some of which specify the particular anomer of glucose (cpd19001_c0 is α-D-glucose, cpd00190_c0 is β-D-glucose, cpd19006_c0 is α-D-glucose-6-phosphate), while others use generic glucose metabolites that seem to collectively represent all anomers of glucose (cpd00027 is D-glucose, cpd00079 is glucose-6-phosphate). As far as I can tell, the different anomers of glucose can spontaneously isomerize into each other without the assistance of any enzymes, and while some enzymes are more or less efficient with certain anomers, it doesn’t seem like any enzymes can only use specific anomers of glucose ([1](https://doi.org/10.1016/j.carres.2006.02.035),[2](https://www.tandfonline.com/doi/pdf/10.1179/acb.2001.050)). It does seem like some of the enzymes involved in [galactose](https://academic.oup.com/femsle/article-abstract/364/20/fnx202/4222790) metabolism only recognize specific anomers of galactose, and it seems plausible that the enzyme responsible for accelerating the interconversion of α- and β-galactose would also act on glucose anomers (as shown by rxn01171_c0). Furthermore, all reactions currently in the model that use α-D-glucose (cpd19001_c0) or β-D-glucose (cpd00190_c0) have otherwise identical counterparts that use D-glucose (cpd00027_c0), so they’re all functionally equivalent and needlessly increasing the total number of reactions and metabolites in the model.

rxn00816_c0: H2O [c0] + LACT [c0] <=> D-Glucose [c0] + Galactose [c0]
rxn15230_c0: H2O [c0] + LACT [c0] <=> Galactose [c0] + alpha-D-Glucose [c0]

rxn00216_c0: ATP [c0] + D-Glucose [c0] <=> ADP [c0] + H+ [c0] + D-glucose-6-phosphate [c0]
rxn15249_c0: ATP [c0] + alpha-D-Glucose [c0] <=> ADP [c0] + H+ [c0] + alpha-D-Glucose 6-phosphate [c0]

rxn00704_c0: Glucose-1-phosphate [c0] <=> D-glucose-6-phosphate [c0]
rxn20583_c0: Glucose-1-phosphate [c0] <=> alpha-D-Glucose 6-phosphate [c0]

rxn04945_c0: NADP [c0] + D-Glucose [c0] <=> NADPH [c0] + H+ [c0] + Gluconolactone [c0]
rxn01108_c0: NAD [c0] + beta-D-Glucose [c0] <=> NADH [c0] + H+ [c0] + Gluconolactone [c0]
rxn01109_c0: NADP [c0] + beta-D-Glucose [c0] <=> NADPH [c0] + H+ [c0] + Gluconolactone [c0]

rxn09978_c0: H2O [c0] + alpha-Methyl-D-glucoside [c0] <=> D-Glucose [c0] + Methanol [c0]
rxn09979_c0: H2O [c0] + beta-Methylglucoside [c0] <=> D-Glucose [c0] + Methanol [c0]

rxn01171_c0: D-Glucose [c0] <=> beta-D-Glucose [c0]

For the record, I came across these while putting together an Escher map of central carbon metabolism in this model.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists