### PR TITLE
Duplicate succinate dehydrogenase reactions

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #203** (CUSTOM-CI)
+- **PR #212** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request

- Removes rxn09272_c0 for being a duplicate of rxn00288_c0+rxn10126_c0
- Removes rxn08527_c0 for being a duplicate of rxn00288_c0+rxn10126_c0
- Removes rxn08528_c0 for being a duplicate of rxn00288_c0+rxn10126_c0

The model currently contains several reactions that represent the succinate dehydrogenase complex, which differ only in the identity of the cofactor that is reduced as succinate is oxidized:

rxn00288_c0: FAD (cpd00015_c0) + Succinate (cpd00036_c0) + H+ (cpd00067_c0) --> Fumarate (cpd00106_c0) + FADH2 (cpd00982_c0)
rxn10126_c0: FADH2 (cpd00982_c0) + Ubiquinone-8 (cpd15560_c0) --> FAD (cpd00015_c0) + H+ (cpd00067_c0) + Ubiquinol-8 (cpd15561_c0)
rxn09272_c0: Succinate (cpd00036_c0) + Ubiquinone-8 (cpd15560_c0) --> Fumarate (cpd00106_c0) + Ubiquinol-8 (cpd15561_c0)
rxn08527_c0: Fumarate (cpd00106_c0) + Menaquinol 8 (cpd15499_c0) <=> Succinate (cpd00036_c0) + Menaquinone 8 (cpd15500_c0)
rxn08528_c0: Fumarate (cpd00106_c0) + 2-Demethylmenaquinol 8 (cpd15353_c0) <=> Succinate (cpd00036_c0) + 2-Demethylmenaquinone 8 (cpd15352_c0)

These all have exactly the same GPR (the subunits of succinate dehydrogenase). Succinate dehydrogenases (seemingly across all organisms) use the electrons from succinate to reduce its FAD cofactor before reducing ubiquinone or any other potential terminal electron acceptors ([source](https://doi.org/10.1016/j.bbabio.2013.01.012)), and only rxn00288_c0+rxn10126_c0 accurately represents this. While there don’t seem to be any redox reactions between FAD(H2) and the menaquinones, every single redox reaction that either menaquinone participates in has an equivalent that uses ubiquinone and is associated with exactly the same genes, so I don’t think that removing the menaquinone variants functionally changes anything about the model. But it would also be easy enough to add such reactions if you want.

I came across this while trying to make an Escher map of central carbon metabolism for the model, which is made more challenging (both in the sense of the effort it takes to make the Escher map and in the sense of making an Escher map that is easily interpreted when you map fluxes to it) when reactions have multiple variants like this that are, at best, not strictly necessary.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists