### PR TITLE
Remove rxn20583_c0

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #212** (CUSTOM-CI)
+- **PR #213** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Removes rxn20583_c0

and makes no other changes to the model.

I meant but forgot to remove rxn20583_c0 for being a duplicate of rxn00704_c0 back in #211. However, since I didn’t forget to remove cpd19006_c0 (alpha-D-glucose-6-phosphate), #211 left rxn20583_c0 with no products, so it could produce glucose-1-phosphate (cpd00089_c0) from nothing, which made it look like the model could grow with no carbon sources if you only checked the bounds of the exchange reactions that involved extracellular metabolites or had IDs in the same format as the rest of the exchange reactions (e.g. EX_cpd00176_e0). This PR fixes that.

**I hereby confirm that I have:**
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
