### PR TITLE
Fix Cysteine Catabolism (and metabolite names)

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #212** (CUSTOM-CI)
+- **PR #214** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Adds rxn47974_c0: Mercaptopyruvate + Reduced Thioredoxin <=> Pyruvate + H<sup>+</sup> + H<sub>2</sub>S + Oxidized Thioredoxin, GPR: TK37_RS13750 and TK37_RS14240

The model can currently turn cysteine into mercaptopyruvate with rxn00647_c0, but has no other reactions that involve mercaptopyruvate, preventing it from catabolizing cysteine. eggNOG annotated TK37_RS13750 and TK37_RS14240 with E.C. 2.8.1.2, which corresponds to ModelSEED [rxn47974](https://modelseed.org/biochem/reactions/rxn47974). Strictly speaking, the reaction this pull requests adds to the model isn’t exactly rxn47974, because ModelSEED has several duplicate thioredoxin metabolites, and rxn47974 uses a different set (cpd28060 and cpd27735) than the pair that’s already in the model (cpd11421 and cpd11420), but I figured that it’s close enough.

Also I just realized that I replaced the [c0] suffixes on all cytosolic metabolite names with the corresponding metabolite IDs, which I only meant to do as a temporary change for writing a PR description, and unintentionally included in one of my previous PRs, so this PR also reverts that.

**I hereby confirm that I have:**
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
