### PR TITLE
Fix Histidine Catabolism

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #212** (CUSTOM-CI)
+- **PR #215** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Makes rxn01639_c0 irreversible in the opposite direction, i.e. N-Formimino-L-glutamate + H<sub>2</sub>O --> L-Glutamate + Formamide
- Adds cpd00378_e0: Formamide [e0]
- Adds rxn05708_c0: Formamide [c0] + H<sup>+</sup> [c0] <-> Formamide [e0] + H<sup>+</sup> [e0]
- Adds EX_cpd00378_e0: Formamide [e0] <->

The model currently has all steps of a histidine catabolism pathway, but it’s blocked because the last step (rxn01639_c0) is irreversible in the wrong direction. Everything I can find (e.g. [KEGG](https://www.kegg.jp/entry/3.5.3.8), [this paper](https://journals.asm.org/doi/full/10.1128/mmbr.00014-12)) says that this reaction is irreversible in the opposite direction, and even [ModelSEED’s ΔG for rxn01639](https://modelseed.org/biochem/reactions/rxn01639) strongly suggests that it goes in the opposite direction from what’s shown on ModelSEED. Also, rxn01639_c0 is the only reaction in the model that involves formamide (cpd00378), which [this paper](https://journals.asm.org/doi/full/10.1128/mmbr.00014-12) says is not metabolized further by organisms that catabolize histidine, so I’ve added a secretion pathway for it. rxn05708 happens to be the only transport reaction ModelSEED has for formamide, and since I couldn’t find anything about formamide transporters, I just went with that.

**I hereby confirm that I have:**
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
