### PR TITLE
Add Lysine to Pipecolate Pathway

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #214** (CUSTOM-CI)
+- **PR #216** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:
- Adds rxn00510_c0: L-Lysine + 2-Oxoglutarate + NADH + H<sup>+</sup> <=> Saccharopine + NAD<sup>+</sup> + H<sub>2</sub>O, GPR: TK37_RS19575
- Adds cpd00352_c0: delta1-Piperideine-6-L-carboxylate [c0]
- Adds rxn01664_c0: 2-Aminoadipate 6-semialdehyde -> delta1-Piperideine-6-L-carboxylate + H<sub>2</sub>O + H<sup>+</sup>, no GPR (see below)
- Adds rxn45861_c0: delta1-Piperideine-6-L-carboxylate + NADPH + 2 H<sup>+</sup> <=>  L-Pipecolate + NADP<sup>+</sup>, GPR: TK37_RS03165
- Sets the name of TK37_RS03165 to proC
- Adds cpd00323_c0: Pipecolate [c0]
- Adds DM_cpd00323_c0: Pipecolate [c0] ->

While looking into lysine catabolism, I noticed that the model has rxn01662_c0:

Saccharopine + NAD<sup>+</sup> + H<sub>2</sub>O <=> 2-Aminoadipate 6-semialdehyde + L-Glutamate + NADH + H<sup>+</sup>

which [this paper](https://academic.oup.com/ismej/article/7/12/2400/7590259) shows as part of one of the known catabolic pathways for lysine. However, rxn01662_c0 is a dead-end in the model, because no other reactions use saccharopine (cpd00351) or 2-aminoadipate 6-semialdehyde (cpd02522). The GFF file and eggNOG both annotated TK37_RS19575 with E.C. 1.5.1.7, which corresponds to [rxn00510](https://modelseed.org/biochem/reactions/rxn00510).

While I couldn’t find any traces of any enzymes responsible for subsequent steps of the lysine catabolism pathway described in that paper, 2-aminoadipate-6-semialdehyde can non-enzymatically cyclize into delta1-Piperideine-6-L-carboxylate (cpd00352), which pyrroline-5-carboxylate reductase (proC) can probably turn into pipecolate (that’s only been directly shown in [E. coli](https://www.jstage.jst.go.jp/article/bbb/66/3/66_3_622/_article/-char/ja/) and proposed to occur in [humans](https://febs.onlinelibrary.wiley.com/doi/10.1016/j.febslet.2009.11.055), but several papers (like this [one](https://www.frontiersin.org/journals/plant-science/articles/10.3389/fpls.2020.00587/full)) seem to assume that that’s probably true of most/all organisms’ pyrroline-5-carboxylate reductases). While I can’t find any evidence that Alteromonas macleodii can metabolize pipecolate any further, [this paper](https://academic.oup.com/ismej/article/7/12/2400/7590259) shows that pipecolate can help some organisms tolerate salt stress, and that some organisms seem to specifically upregulate the lysine to pipecolate pathway in response to salt stress, and it seems plausible that A. macleodii does the same. The best way I could think of to represent that in a GSMM was to just add a sink reaction for pipecolate.

**I hereby confirm that I have:**
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
