### PR TITLE
Fix gene ID situation

### DIFF
--- a/model.json
+++ b/model.json
@@ -19781,7 +19781,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16725",
+"gene_reaction_rule":"WP_049588708.1",
 "annotation":{
 "bigg.reaction":[
 "FOLD3m",
@@ -19829,7 +19829,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03200 and TK37_RS08665",
+"gene_reaction_rule":"WP_049586041.1 and WP_049587105.1",
 "annotation":{
 "bigg.reaction":[
 "GTHS",
@@ -19865,7 +19865,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04425 and TK37_RS04420",
+"gene_reaction_rule":"WP_049586269.1 and WP_049586267.1",
 "annotation":{
 "ec-code":"1.2.4.4",
 "kegg.orthology":[
@@ -19894,7 +19894,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05485",
+"gene_reaction_rule":"WP_014949139.1",
 "annotation":{
 "bigg.reaction":[
 "HXPRT",
@@ -19929,7 +19929,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12730 and TK37_RS08605 and TK37_RS19985",
+"gene_reaction_rule":"WP_049588012.1 and WP_049587097.1 and WP_049589131.1",
 "annotation":{
 "bigg.reaction":[
 "SERAT",
@@ -19962,7 +19962,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16320",
+"gene_reaction_rule":"WP_014976668.1",
 "annotation":{
 "bigg.reaction":[
 "U18",
@@ -20003,7 +20003,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19165",
+"gene_reaction_rule":"WP_014976833.1",
 "annotation":{
 "bigg.reaction":[
 "U207",
@@ -20027,7 +20027,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03350",
+"gene_reaction_rule":"WP_049586056.1",
 "annotation":{
 "ec-code":"2.4.1.227",
 "kegg.orthology":"K02563",
@@ -20052,7 +20052,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11825 and TK37_RS11830",
+"gene_reaction_rule":"WP_039225570.1 and WP_039225252.1",
 "annotation":{
 "biocyc":"META:ISOCHORMAT-RXN",
 "ec-code":"3.3.2.1",
@@ -20077,7 +20077,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08435 and TK37_RS11220 and TK37_RS11660 and TK37_RS03755 and TK37_RS18545",
+"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
 "annotation":{
 "ec-code":"6.2.1.3",
 "metanetx.reaction":"MNXR134818",
@@ -20099,7 +20099,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01400",
+"gene_reaction_rule":"WP_080986367.1",
 "annotation":{
 "bigg.reaction":[
 "GLUCYS",
@@ -20138,7 +20138,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12790",
+"gene_reaction_rule":"WP_049588021.1",
 "annotation":{
 "bigg.reaction":[
 "NDPK7",
@@ -20172,7 +20172,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00180",
+"gene_reaction_rule":"WP_049585467.1",
 "annotation":{
 "bigg.reaction":[
 "PPCK",
@@ -20203,7 +20203,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18875 and TK37_RS16105",
+"gene_reaction_rule":"WP_014949030.1 and WP_049588640.1",
 "annotation":{
 "bigg.reaction":[
 "NO2t2r",
@@ -20227,7 +20227,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03460",
+"gene_reaction_rule":"WP_049586085.1",
 "annotation":{
 "ec-code":"1.2.4.1",
 "kegg.orthology":[
@@ -20254,7 +20254,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08950",
+"gene_reaction_rule":"WP_049587157.1",
 "annotation":{
 "bigg.reaction":[
 "MAL12",
@@ -20298,7 +20298,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04710",
+"gene_reaction_rule":"WP_080986386.1",
 "annotation":{
 "ec-code":"2.7.8.12",
 "metanetx.reaction":"MNXR136293",
@@ -20315,7 +20315,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18240",
+"gene_reaction_rule":"WP_049588897.1",
 "annotation":{
 "bigg.reaction":[
 "TDPDREi",
@@ -20346,7 +20346,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16705 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715",
+"gene_reaction_rule":"WP_049588707.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1",
 "annotation":{
 "bigg.reaction":[
 "HACD7p",
@@ -20385,7 +20385,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16990",
+"gene_reaction_rule":"WP_049588745.1",
 "annotation":{
 "bigg.reaction":"FAS1_6_c",
 "metanetx.reaction":"MNXR123649",
@@ -20404,7 +20404,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12790",
+"gene_reaction_rule":"WP_049588021.1",
 "annotation":{
 "ec-code":"2.7.4.6",
 "kegg.orthology":"K00940",
@@ -20426,7 +20426,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15280",
+"gene_reaction_rule":"WP_014948150.1",
 "annotation":{
 "bigg.reaction":"HEPTT",
 "ec-code":"2.5.1.-",
@@ -20449,7 +20449,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03700",
+"gene_reaction_rule":"WP_049586133.1",
 "annotation":{
 "bigg.reaction":"PDX5PS2",
 "biocyc":"META:PDXJ-RXN",
@@ -20476,7 +20476,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06515",
+"gene_reaction_rule":"WP_049586716.1",
 "annotation":{
 "bigg.reaction":[
 "IDP3_2",
@@ -20508,7 +20508,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04255",
+"gene_reaction_rule":"WP_049586236.1",
 "annotation":{
 "bigg.reaction":[
 "HIBHr",
@@ -20538,7 +20538,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06155",
+"gene_reaction_rule":"WP_049586630.1",
 "annotation":{
 "ec-code":"2.7.8.8",
 "metanetx.reaction":"MNXR136227",
@@ -20557,7 +20557,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17380",
+"gene_reaction_rule":"WP_049588781.1",
 "annotation":{
 "bigg.reaction":"SOTA",
 "biocyc":"META:SUCCORNTRANSAM-RXN",
@@ -20589,7 +20589,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08900",
+"gene_reaction_rule":"WP_014950281.1",
 "annotation":{
 "bigg.reaction":[
 "BETALDHx",
@@ -20620,7 +20620,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06025",
+"gene_reaction_rule":"WP_049586604.1",
 "annotation":{
 "ec-code":"3.1.3.27",
 "metanetx.reaction":"MNXR136266",
@@ -20639,7 +20639,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02750 or (TK37_RS13980 and TK37_RS20685) or (TK37_RS04495 and TK37_RS07675) or TK37_RS05630 or TK37_RS18985 or TK37_RS05630",
+"gene_reaction_rule":"WP_049585982.1 or (WP_014999437.1 and WP_053103828.1) or (WP_049586284.1 and WP_080986400.1) or WP_049586533.1 or WP_049589000.1 or WP_049586533.1",
 "annotation":{
 "bigg.reaction":[
 "AMPEP13",
@@ -20671,7 +20671,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01635 and TK37_RS01650",
+"gene_reaction_rule":"WP_014948795.1 and WP_049585842.1",
 "annotation":{
 "bigg.reaction":"SADT2",
 "metanetx.reaction":"MNXR104241",
@@ -20691,7 +20691,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16320",
+"gene_reaction_rule":"WP_014976668.1",
 "annotation":{
 "bigg.reaction":[
 "U17",
@@ -20731,7 +20731,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06495 or TK37_RS06495",
+"gene_reaction_rule":"WP_039229483.1 or WP_039229483.1",
 "annotation":{
 "bigg.reaction":[
 "ADE13_2",
@@ -20763,7 +20763,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07955",
+"gene_reaction_rule":"WP_014950808.1",
 "annotation":{
 "ec-code":"2.7.1.48",
 "kegg.reaction":"R02371",
@@ -20786,7 +20786,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10685",
+"gene_reaction_rule":"WP_049587528.1",
 "annotation":{
 "bigg.reaction":[
 "U92",
@@ -20821,7 +20821,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18255",
+"gene_reaction_rule":"WP_049588900.1",
 "annotation":{
 "bigg.reaction":[
 "UDPGD",
@@ -20852,7 +20852,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11955 and TK37_RS05240",
+"gene_reaction_rule":"WP_049587803.1 and WP_014951417.1",
 "annotation":{
 "bigg.reaction":"GLU5K",
 "biocyc":"META:GLUTKIN-RXN",
@@ -20882,7 +20882,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15765",
+"gene_reaction_rule":"WP_049588592.1",
 "annotation":{
 "bigg.reaction":"CAT23DOX",
 "biocyc":"META:CATECHOL-23-DIOXYGENASE-RXN",
@@ -20915,7 +20915,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS20115",
+"gene_reaction_rule":"WP_049589172.1",
 "annotation":{
 "ec-code":[
 "6.3.2.17",
@@ -20942,7 +20942,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14350 or (TK37_RS02700 and TK37_RS11690 and TK37_RS11865 and TK37_RS13200 and TK37_RS14960 and TK37_RS02270)",
+"gene_reaction_rule":"WP_049588331.1 or (WP_044556927.1 and WP_049587731.1 and WP_049587772.1 and WP_049588110.1 and WP_049588449.1 and WP_014948922.1)",
 "annotation":{
 "bigg.reaction":[
 "ACGSm",
@@ -20980,7 +20980,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04095 and TK37_RS14380",
+"gene_reaction_rule":"WP_049586202.1 and WP_049588338.1",
 "annotation":{
 "bigg.reaction":[
 "U28",
@@ -21026,7 +21026,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19165",
+"gene_reaction_rule":"WP_014976833.1",
 "annotation":{
 "bigg.reaction":[
 "SUCCt2r",
@@ -21052,7 +21052,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04315",
+"gene_reaction_rule":"WP_049586246.1",
 "annotation":{
 "bigg.reaction":[
 "PFK",
@@ -21085,7 +21085,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1E161pp",
 "ec-code":"3.1.1.5",
@@ -21106,7 +21106,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04315",
+"gene_reaction_rule":"WP_049586246.1",
 "annotation":{
 "ec-code":"2.7.1.11",
 "kegg.orthology":[
@@ -21132,7 +21132,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17625",
+"gene_reaction_rule":"WP_020744244.1",
 "annotation":{
 "bigg.reaction":"MMSAD3",
 "biocyc":[
@@ -21168,7 +21168,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10445 and TK37_RS19485",
+"gene_reaction_rule":"WP_049587504.1 and WP_012516907.1",
 "annotation":{
 "metanetx.reaction":"MNXR136339",
 "sbo":"SBO:0000655",
@@ -21186,7 +21186,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16140",
+"gene_reaction_rule":"WP_049588647.1",
 "annotation":{
 "bigg.reaction":[
 "HIS5",
@@ -21214,7 +21214,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01055",
+"gene_reaction_rule":"WP_014951100.1",
 "annotation":{
 "bigg.reaction":"UPPDC2",
 "biocyc":"META:RXN-10642",
@@ -21237,7 +21237,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08320",
+"gene_reaction_rule":"WP_049587066.1",
 "annotation":{
 "bigg.reaction":[
 "DHNPAm",
@@ -21274,7 +21274,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05800",
+"gene_reaction_rule":"WP_049586577.1",
 "annotation":{
 "biocyc":"META:RXN0-884",
 "ec-code":"1.17.1.2",
@@ -21297,7 +21297,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05895",
+"gene_reaction_rule":"WP_014976996.1",
 "annotation":{
 "bigg.reaction":[
 "ASPO1",
@@ -21330,7 +21330,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01930",
+"gene_reaction_rule":"WP_049585873.1",
 "annotation":{
 "biocyc":"META:H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN",
 "ec-code":[
@@ -21363,7 +21363,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16035",
+"gene_reaction_rule":"WP_014950051.1",
 "annotation":{
 "biocyc":"META:RXN-14270",
 "ec-code":"2.4.2.7",
@@ -21386,7 +21386,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13780",
+"gene_reaction_rule":"WP_049588224.1",
 "annotation":{
 "ec-code":"2.7.8.5",
 "metanetx.reaction":"MNXR136258",
@@ -21406,7 +21406,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15975 and TK37_RS15980 and TK37_RS15985 and TK37_RS15990",
+"gene_reaction_rule":"WP_012518362.1 and WP_014949447.1 and WP_014949446.1 and WP_014949445.1",
 "annotation":{
 "bigg.reaction":"SUCD4",
 "metanetx.reaction":"MNXR104630",
@@ -21425,7 +21425,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14890",
+"gene_reaction_rule":"WP_014951390.1",
 "annotation":{
 "ec-code":"2.3.1.15",
 "metanetx.reaction":"MNXR136206",
@@ -21445,7 +21445,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13935",
+"gene_reaction_rule":"WP_049588248.1",
 "annotation":{
 "bigg.reaction":"AGPAT140",
 "ec-code":"2.3.1.51",
@@ -21466,7 +21466,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02780",
+"gene_reaction_rule":"WP_014948557.1",
 "annotation":{
 "ec-code":"2.7.7.41",
 "metanetx.reaction":"MNXR136221",
@@ -21484,7 +21484,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14880",
+"gene_reaction_rule":"WP_014977810.1",
 "annotation":{
 "ec-code":"4.2.1.9",
 "kegg.orthology":"K01687",
@@ -21508,7 +21508,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560 or TK37_RS02805",
+"gene_reaction_rule":"WP_014949559.1 or WP_014948562.1",
 "annotation":{
 "bigg.reaction":[
 "3HAD80",
@@ -21542,7 +21542,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14890",
+"gene_reaction_rule":"WP_014951390.1",
 "annotation":{
 "ec-code":"2.3.1.15",
 "metanetx.reaction":"MNXR136202",
@@ -21561,7 +21561,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06005",
+"gene_reaction_rule":"WP_014950089.1",
 "annotation":{
 "bigg.reaction":[
 "U79",
@@ -21594,7 +21594,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19680",
+"gene_reaction_rule":"WP_049589075.1",
 "annotation":{
 "bigg.reaction":[
 "GALIGH",
@@ -21625,7 +21625,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560",
+"gene_reaction_rule":"WP_014949559.1",
 "annotation":{
 "ec-code":"4.2.1.0",
 "metanetx.reaction":"MNXR134874",
@@ -21644,7 +21644,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14835",
+"gene_reaction_rule":"WP_049588435.1",
 "annotation":{
 "bigg.reaction":"G3PD5",
 "biocyc":[
@@ -21673,7 +21673,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17275",
+"gene_reaction_rule":"WP_039229281.1",
 "annotation":{
 "bigg.reaction":[
 "AMID2",
@@ -21702,7 +21702,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14675",
+"gene_reaction_rule":"WP_049588403.1",
 "annotation":{
 "bigg.reaction":[
 "LACZ",
@@ -21742,7 +21742,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02000",
+"gene_reaction_rule":"WP_049585876.1",
 "annotation":{
 "bigg.reaction":[
 "QULNS",
@@ -21773,7 +21773,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03035",
+"gene_reaction_rule":"WP_049586019.1",
 "annotation":{
 "bigg.reaction":[
 "HMGDx",
@@ -21806,7 +21806,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00600 and TK37_RS13175",
+"gene_reaction_rule":"WP_049585588.1 and WP_014950548.1",
 "annotation":{
 "bigg.reaction":"MTAN",
 "biocyc":"META:METHYLTHIOADENOSINE-NUCLEOSIDASE-RXN",
@@ -21842,7 +21842,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14885 or TK37_RS04390 or TK37_RS16795",
+"gene_reaction_rule":"WP_014977809.1 or WP_049586260.1 or WP_049588717.1",
 "annotation":{
 "bigg.reaction":[
 "SERD_Lr",
@@ -21883,7 +21883,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06155",
+"gene_reaction_rule":"WP_049586630.1",
 "annotation":{
 "ec-code":"2.7.8.8",
 "metanetx.reaction":"MNXR136224",
@@ -21900,7 +21900,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03910",
+"gene_reaction_rule":"WP_049586168.1",
 "annotation":{
 "bigg.reaction":"A5PISO",
 "biocyc":"META:DARAB5PISOM-RXN",
@@ -21927,7 +21927,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03640",
+"gene_reaction_rule":"WP_049586127.1",
 "annotation":{
 "bigg.reaction":"AP5AH",
 "biocyc":"META:RXN-10966",
@@ -21950,7 +21950,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08525",
+"gene_reaction_rule":"WP_014947861.1",
 "annotation":{
 "bigg.reaction":[
 "PPAm",
@@ -21977,7 +21977,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560",
+"gene_reaction_rule":"WP_014949559.1",
 "annotation":{
 "ec-code":"4.2.1.0",
 "metanetx.reaction":"MNXR134866",
@@ -21998,7 +21998,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04050",
+"gene_reaction_rule":"WP_049586190.1",
 "annotation":{
 "bigg.reaction":"E4PD",
 "biocyc":"META:ERYTH4PDEHYDROG-RXN",
@@ -22024,7 +22024,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12045 and TK37_RS16635",
+"gene_reaction_rule":"WP_049587825.1 and WP_014949348.1",
 "annotation":{
 "bigg.reaction":"MDDEP1pp",
 "metanetx.reaction":"MNXR101434",
@@ -22045,7 +22045,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17625",
+"gene_reaction_rule":"WP_020744244.1",
 "annotation":{
 "bigg.reaction":[
 "MMSAD1",
@@ -22071,7 +22071,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04130",
+"gene_reaction_rule":"WP_039224609.1",
 "annotation":{
 "metanetx.reaction":"MNXR136581",
 "sbo":"SBO:0000655",
@@ -22089,7 +22089,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16350",
+"gene_reaction_rule":"WP_039234640.1",
 "annotation":{
 "bigg.reaction":[
 "OMPDC",
@@ -22123,7 +22123,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2A120",
 "ec-code":"3.1.1.5",
@@ -22142,7 +22142,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17405",
+"gene_reaction_rule":"WP_049588784.1",
 "annotation":{
 "bigg.reaction":[
 "DHEDAA",
@@ -22170,7 +22170,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19405",
+"gene_reaction_rule":"WP_014950980.1",
 "annotation":{
 "bigg.reaction":[
 "MTHFR3",
@@ -22205,7 +22205,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09195",
+"gene_reaction_rule":"WP_049587218.1",
 "annotation":{
 "ec-code":"2.1.1.-",
 "metanetx.reaction":"MNXR136766",
@@ -22225,7 +22225,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07955",
+"gene_reaction_rule":"WP_014950808.1",
 "annotation":{
 "ec-code":"2.7.1.48",
 "kegg.reaction":"R01549",
@@ -22245,7 +22245,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10360 and TK37_RS13625",
+"gene_reaction_rule":"WP_015066029.1 and WP_014976618.1",
 "annotation":{
 "bigg.reaction":"DAGK141",
 "ec-code":"2.7.1.107",
@@ -22267,7 +22267,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17530 and TK37_RS17535",
+"gene_reaction_rule":"WP_049588804.1 and WP_049588805.1",
 "annotation":{
 "bigg.reaction":[
 "XANDa",
@@ -22308,7 +22308,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02440",
+"gene_reaction_rule":"WP_014948475.1",
 "annotation":{
 "bigg.reaction":[
 "NTPP11",
@@ -22345,7 +22345,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10360 and TK37_RS13625",
+"gene_reaction_rule":"WP_015066029.1 and WP_014976618.1",
 "annotation":{
 "ec-code":"2.7.1.107",
 "metanetx.reaction":"MNXR136250",
@@ -22363,7 +22363,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07240 and TK37_RS07245",
+"gene_reaction_rule":"WP_049586836.1 and WP_049586837.1",
 "annotation":{
 "bigg.reaction":"TRPS3r",
 "biocyc":"META:RXN0-2381",
@@ -22396,7 +22396,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1A120pp",
 "ec-code":"3.1.1.5",
@@ -22416,7 +22416,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18845",
+"gene_reaction_rule":"WP_049588978.1",
 "annotation":{
 "bigg.reaction":"MLTP1",
 "biocyc":"META:RXN-14284",
@@ -22440,7 +22440,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12160",
+"gene_reaction_rule":"WP_049587853.1",
 "annotation":{
 "bigg.reaction":"TDSK",
 "biocyc":"META:TETRAACYLDISACC4KIN-RXN",
@@ -22470,7 +22470,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08535",
+"gene_reaction_rule":"WP_080986403.1",
 "annotation":{
 "bigg.reaction":"UM4PL",
 "metanetx.reaction":"MNXR142343",
@@ -22490,7 +22490,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17990",
+"gene_reaction_rule":"WP_014949022.1",
 "annotation":{
 "bigg.reaction":"KDOPS",
 "biocyc":"META:KDO-8PSYNTH-RXN",
@@ -22520,7 +22520,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02750 or (TK37_RS13980 and TK37_RS20685) or (TK37_RS04495 and TK37_RS07675) or TK37_RS05630 or TK37_RS18985 or TK37_RS05630",
+"gene_reaction_rule":"WP_049585982.1 or (WP_014999437.1 and WP_053103828.1) or (WP_049586284.1 and WP_080986400.1) or WP_049586533.1 or WP_049589000.1 or WP_049586533.1",
 "annotation":{
 "ec-code":"3.4.11.2",
 "metanetx.reaction":"MNXR100357",
@@ -22539,7 +22539,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03050 and TK37_RS03625",
+"gene_reaction_rule":"WP_049586022.1 and WP_049586124.1",
 "annotation":{
 "bigg.reaction":[
 "ASPKi",
@@ -22572,7 +22572,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11950 and TK37_RS01655",
+"gene_reaction_rule":"WP_049587801.1 and WP_049585843.1",
 "annotation":{
 "bigg.reaction":[
 "PROt4r",
@@ -22597,7 +22597,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02780",
+"gene_reaction_rule":"WP_014948557.1",
 "annotation":{
 "bigg.reaction":"DASYN141",
 "ec-code":"2.7.7.41",
@@ -22618,7 +22618,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05605",
+"gene_reaction_rule":"WP_080986392.1",
 "annotation":{
 "bigg.reaction":"HKYNH",
 "ec-code":"3.7.1.3",
@@ -22643,7 +22643,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05940 and TK37_RS17035",
+"gene_reaction_rule":"WP_014950101.1 and WP_039229648.1",
 "annotation":{
 "bigg.reaction":[
 "PDX3_5",
@@ -22678,7 +22678,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2A181",
 "ec-code":"3.1.1.5",
@@ -22698,7 +22698,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09595",
+"gene_reaction_rule":"WP_049587312.1",
 "annotation":{
 "bigg.reaction":[
 "PDE2_1",
@@ -22749,7 +22749,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16985 or TK37_RS11900 or TK37_RS17005",
+"gene_reaction_rule":"WP_014949212.1 or WP_014949953.1 or WP_049588746.1",
 "annotation":{
 "bigg.reaction":[
 "FAS2_2_1",
@@ -22786,7 +22786,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19280",
+"gene_reaction_rule":"WP_049589036.1",
 "annotation":{
 "bigg.reaction":[
 "HISD1",
@@ -22820,7 +22820,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00755",
+"gene_reaction_rule":"WP_049585628.1",
 "annotation":{
 "bigg.reaction":[
 "HCYSMT",
@@ -22851,7 +22851,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05595 or (TK37_RS15255 and TK37_RS01710 and TK37_RS17085)",
+"gene_reaction_rule":"WP_049586525.1 or (WP_024015658.1 and WP_049585851.1 and WP_049588755.1)",
 "annotation":{
 "bigg.reaction":[
 "KAT3",
@@ -22883,7 +22883,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11035",
+"gene_reaction_rule":"WP_049587596.1",
 "annotation":{
 "bigg.reaction":[
 "MLTG1",
@@ -22942,7 +22942,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560 or TK37_RS02805",
+"gene_reaction_rule":"WP_014949559.1 or WP_014948562.1",
 "annotation":{
 "ec-code":"4.2.1.0",
 "metanetx.reaction":"MNXR134883",
@@ -22964,7 +22964,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10445 and TK37_RS19485",
+"gene_reaction_rule":"WP_049587504.1 and WP_012516907.1",
 "annotation":{
 "bigg.reaction":[
 "CD2abcpp",
@@ -22999,7 +22999,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18040",
+"gene_reaction_rule":"WP_049588866.1",
 "annotation":{
 "bigg.reaction":"AHSERL4",
 "ec-code":[
@@ -23035,7 +23035,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01610 or TK37_RS09160",
+"gene_reaction_rule":"WP_014948790.1 or WP_049587207.1",
 "annotation":{
 "bigg.reaction":[
 "ASN2",
@@ -23067,7 +23067,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12985",
+"gene_reaction_rule":"WP_049588054.1",
 "annotation":{
 "biocyc":"META:RXN-9990",
 "ec-code":"2.7.7.43",
@@ -23093,7 +23093,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04250",
+"gene_reaction_rule":"WP_039227752.1",
 "annotation":{
 "bigg.reaction":[
 "ACOADH1",
@@ -23118,7 +23118,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06155",
+"gene_reaction_rule":"WP_049586630.1",
 "annotation":{
 "bigg.reaction":"PSSA140",
 "ec-code":"2.7.8.8",
@@ -23138,7 +23138,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15970",
+"gene_reaction_rule":"WP_049588626.1",
 "annotation":{
 "ec-code":"1.2.4.2",
 "kegg.orthology":[
@@ -23168,7 +23168,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17000",
+"gene_reaction_rule":"WP_012518211.1",
 "annotation":{
 "bigg.reaction":"AACPS4",
 "ec-code":"6.2.1.20",
@@ -23189,7 +23189,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06155",
+"gene_reaction_rule":"WP_049586630.1",
 "annotation":{
 "bigg.reaction":"PSSA161",
 "ec-code":"2.7.8.8",
@@ -23212,7 +23212,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10685",
+"gene_reaction_rule":"WP_049587528.1",
 "annotation":{
 "bigg.reaction":"PPNCL3",
 "biocyc":"META:RXN66-555",
@@ -23243,7 +23243,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14220",
+"gene_reaction_rule":"WP_049588313.1",
 "annotation":{
 "bigg.reaction":[
 "GPDDA4pp",
@@ -23270,7 +23270,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02485",
+"gene_reaction_rule":"WP_049585950.1",
 "annotation":{
 "bigg.reaction":[
 "LEU4",
@@ -23310,7 +23310,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS20170 and TK37_RS00330 and TK37_RS00325",
+"gene_reaction_rule":"WP_039222269.1 and WP_014951276.1 and WP_039228980.1",
 "annotation":{
 "bigg.reaction":"BTNC",
 "ec-code":"6.3.4.14",
@@ -23337,7 +23337,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18040",
+"gene_reaction_rule":"WP_049588866.1",
 "annotation":{
 "bigg.reaction":[
 "CYSS",
@@ -23374,7 +23374,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17325",
+"gene_reaction_rule":"WP_014948032.1",
 "annotation":{
 "bigg.reaction":[
 "ARO1_4",
@@ -23405,7 +23405,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04095 and TK37_RS14380",
+"gene_reaction_rule":"WP_049586202.1 and WP_049588338.1",
 "annotation":{
 "biocyc":"META:RXN-14227",
 "ec-code":"3.1.3.5",
@@ -23438,7 +23438,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01855 or TK37_RS16315",
+"gene_reaction_rule":"WP_014976023.1 or WP_049588672.1",
 "annotation":{
 "bigg.reaction":[
 "U52",
@@ -23473,7 +23473,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06570",
+"gene_reaction_rule":"WP_049586730.1",
 "annotation":{
 "bigg.reaction":[
 "MAN1PT",
@@ -23509,7 +23509,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01635 or TK37_RS01645",
+"gene_reaction_rule":"WP_014948795.1 or WP_049585841.1",
 "annotation":{
 "bigg.reaction":[
 "MET14",
@@ -23541,7 +23541,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS10875 and TK37_RS08230 and TK37_RS09355 and TK37_RS20075 and TK37_RS17090 and TK37_RS04250 and TK37_RS08845 and TK37_RS18115 and TK37_RS09010) or TK37_RS18115",
+"gene_reaction_rule":"(WP_014947786.1 and WP_049587019.1 and WP_049587262.1 and WP_049589161.1 and WP_014949232.1 and WP_039227752.1 and WP_049587138.1 and WP_014976690.1 and WP_049587170.1) or WP_014976690.1",
 "annotation":{
 "bigg.reaction":"ACOAD3f",
 "ec-code":[
@@ -23575,7 +23575,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04425 and TK37_RS04420",
+"gene_reaction_rule":"WP_049586269.1 and WP_049586267.1",
 "annotation":{
 "ec-code":"1.2.4.4",
 "kegg.orthology":[
@@ -23601,7 +23601,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08580",
+"gene_reaction_rule":"WP_049587091.1",
 "annotation":{
 "bigg.reaction":"DAPE",
 "biocyc":"META:DIAMINOPIMEPIM-RXN",
@@ -23625,7 +23625,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08830",
+"gene_reaction_rule":"WP_039226917.1",
 "annotation":{
 "bigg.reaction":[
 "PPGPP",
@@ -23660,7 +23660,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02750 or (TK37_RS13980 and TK37_RS20685) or (TK37_RS04495 and TK37_RS07675) or TK37_RS05630 or TK37_RS18985 or TK37_RS05630",
+"gene_reaction_rule":"WP_049585982.1 or (WP_014999437.1 and WP_053103828.1) or (WP_049586284.1 and WP_080986400.1) or WP_049586533.1 or WP_049589000.1 or WP_049586533.1",
 "annotation":{
 "bigg.reaction":"MEAMP1(ala-gly)",
 "biocyc":"META:RXN0-6977",
@@ -23684,7 +23684,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08140 and TK37_RS08135",
+"gene_reaction_rule":"WP_014975661.1 and WP_049586997.1",
 "annotation":{
 "bigg.reaction":"NTRIR2x",
 "biocyc":[
@@ -23724,7 +23724,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00615",
+"gene_reaction_rule":"WP_014951193.1",
 "annotation":{
 "bigg.reaction":"NADH10",
 "ec-code":"1.6.5.3",
@@ -23744,7 +23744,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01435",
+"gene_reaction_rule":"WP_049585822.1",
 "annotation":{
 "bigg.reaction":[
 "INSt2rpp",
@@ -23771,7 +23771,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03285 and TK37_RS10590 and TK37_RS10595 and TK37_RS03275 and TK37_RS10600 and TK37_RS03280",
+"gene_reaction_rule":"WP_049586048.1 and WP_012516834.1 and WP_049587498.1 and WP_039227932.1 and WP_014996986.1 and WP_049586047.1",
 "annotation":{
 "bigg.reaction":"CUt3",
 "metanetx.reaction":"MNXR135764",
@@ -23790,7 +23790,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10950",
+"gene_reaction_rule":"WP_014947801.1",
 "annotation":{
 "bigg.reaction":[
 "HEM3",
@@ -23823,7 +23823,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07010",
+"gene_reaction_rule":"WP_049586785.1",
 "annotation":{
 "bigg.reaction":"ACKr",
 "biocyc":[
@@ -23855,7 +23855,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16985 or TK37_RS11900 or TK37_RS17005",
+"gene_reaction_rule":"WP_014949212.1 or WP_014949953.1 or WP_049588746.1",
 "annotation":{
 "bigg.reaction":[
 "MCMAT3",
@@ -23892,7 +23892,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14210",
+"gene_reaction_rule":"WP_014948076.1",
 "annotation":{
 "bigg.reaction":"PSD140",
 "ec-code":"4.1.1.65",
@@ -23913,7 +23913,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2E120",
 "ec-code":"3.1.1.5",
@@ -23962,7 +23962,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10990",
+"gene_reaction_rule":"WP_014949855.1",
 "annotation":{
 "bigg.reaction":[
 "PYK",
@@ -23994,7 +23994,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03415",
+"gene_reaction_rule":"WP_049586074.1",
 "annotation":{
 "bigg.reaction":[
 "DPCOAKm",
@@ -24030,7 +24030,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15195 and TK37_RS19175",
+"gene_reaction_rule":"WP_049588500.1 and WP_014976831.1",
 "annotation":{
 "bigg.reaction":[
 "2DGLCNDH",
@@ -24057,7 +24057,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02440",
+"gene_reaction_rule":"WP_014948475.1",
 "annotation":{
 "bigg.reaction":[
 "NTPP9",
@@ -24095,7 +24095,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16150 or TK37_RS16150",
+"gene_reaction_rule":"WP_014950027.1 or WP_014950027.1",
 "annotation":{
 "bigg.reaction":[
 "ATPPRTr",
@@ -24127,7 +24127,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14860 or TK37_RS14860 or TK37_RS14860",
+"gene_reaction_rule":"WP_014951396.1 or WP_014951396.1 or WP_014951396.1",
 "annotation":{
 "biocyc":"META:RXN-14106",
 "ec-code":[
@@ -24155,7 +24155,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560 or TK37_RS02805",
+"gene_reaction_rule":"WP_014949559.1 or WP_014948562.1",
 "annotation":{
 "ec-code":"4.2.1.0",
 "metanetx.reaction":"MNXR134887",
@@ -24175,7 +24175,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00615",
+"gene_reaction_rule":"WP_014951193.1",
 "annotation":{
 "bigg.reaction":"NADH9",
 "biocyc":"META:NQOR-RXN",
@@ -24201,7 +24201,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11030",
+"gene_reaction_rule":"WP_014976817.1",
 "annotation":{
 "bigg.reaction":[
 "GAPD",
@@ -24238,7 +24238,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12720",
+"gene_reaction_rule":"WP_014950183.1",
 "annotation":{
 "bigg.reaction":"MI1PP",
 "biocyc":[
@@ -24272,7 +24272,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18815",
+"gene_reaction_rule":"WP_080986474.1",
 "annotation":{
 "bigg.reaction":[
 "GLUt4i",
@@ -24297,7 +24297,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00905",
+"gene_reaction_rule":"WP_049585669.1",
 "annotation":{
 "biocyc":"META:SULFITE-OXIDASE-RXN",
 "ec-code":"1.8.3.1",
@@ -24323,7 +24323,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04530",
+"gene_reaction_rule":"WP_049586293.1",
 "annotation":{
 "bigg.reaction":"DHORD5",
 "ec-code":"1.3.3.1",
@@ -24341,7 +24341,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19170",
+"gene_reaction_rule":"WP_049589026.1",
 "annotation":{
 "bigg.reaction":[
 "KDUI",
@@ -24365,7 +24365,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10945",
+"gene_reaction_rule":"WP_039226924.1",
 "annotation":{
 "bigg.reaction":[
 "HEM4",
@@ -24396,7 +24396,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01435",
+"gene_reaction_rule":"WP_049585822.1",
 "annotation":{
 "bigg.reaction":[
 "CYTDt2rpp",
@@ -24424,7 +24424,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14210",
+"gene_reaction_rule":"WP_014948076.1",
 "annotation":{
 "bigg.reaction":"PSD180",
 "ec-code":"4.1.1.65",
@@ -24445,7 +24445,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS18685 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715 and TK37_RS11765 and TK37_RS01845) or (TK37_RS16705 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715)",
+"gene_reaction_rule":"(WP_049588954.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1 and WP_014976911.1 and WP_014948837.1) or (WP_049588707.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1)",
 "annotation":{
 "bigg.reaction":[
 "HACD1i",
@@ -24483,7 +24483,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03335",
+"gene_reaction_rule":"WP_014950432.1",
 "annotation":{
 "bigg.reaction":"PAPPT2",
 "ec-code":"2.7.8.13",
@@ -24508,7 +24508,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16075",
+"gene_reaction_rule":"WP_049588635.1",
 "annotation":{
 "bigg.reaction":[
 "ADK1m",
@@ -24541,7 +24541,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03915 and TK37_RS02150",
+"gene_reaction_rule":"WP_014948348.1 and WP_049585898.1",
 "annotation":{
 "bigg.reaction":[
 "CAt4i",
@@ -24564,7 +24564,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17330",
+"gene_reaction_rule":"WP_049588776.1",
 "annotation":{
 "bigg.reaction":[
 "ARO1_1",
@@ -24598,7 +24598,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09410",
+"gene_reaction_rule":"WP_049587271.1",
 "annotation":{
 "bigg.reaction":[
 "ALATA_L",
@@ -24634,7 +24634,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05545 and TK37_RS02705",
+"gene_reaction_rule":"WP_014976266.1 and WP_049585977.1",
 "annotation":{
 "bigg.reaction":[
 "GLGC",
@@ -24671,7 +24671,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07910",
+"gene_reaction_rule":"WP_049586958.1",
 "annotation":{
 "bigg.reaction":[
 "EAR120x",
@@ -24705,7 +24705,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10445 and TK37_RS13690 and TK37_RS19485",
+"gene_reaction_rule":"WP_049587504.1 and WP_049588217.1 and WP_012516907.1",
 "annotation":{
 "bigg.reaction":"Cuabc",
 "metanetx.reaction":"MNXR96952",
@@ -24725,7 +24725,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05460",
+"gene_reaction_rule":"WP_049586488.1",
 "annotation":{
 "bigg.reaction":"CYRDAAT",
 "biocyc":"META:R344-RXN",
@@ -24756,7 +24756,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14575 and TK37_RS05985",
+"gene_reaction_rule":"WP_049588376.1 and WP_049586601.1",
 "annotation":{
 "bigg.reaction":[
 "GHMT2",
@@ -24789,7 +24789,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14345",
+"gene_reaction_rule":"WP_014948049.1",
 "annotation":{
 "biocyc":"META:ARGSUCCINLYA-RXN",
 "ec-code":"4.3.2.1",
@@ -24816,7 +24816,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04445",
+"gene_reaction_rule":"WP_049586274.1",
 "annotation":{
 "bigg.reaction":[
 "PTE11x",
@@ -24841,7 +24841,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05300 and TK37_RS16135",
+"gene_reaction_rule":"WP_049586453.1 and WP_049588646.1",
 "annotation":{
 "bigg.reaction":[
 "HISTP",
@@ -24877,7 +24877,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1A181pp",
 "ec-code":"3.1.1.5",
@@ -24898,7 +24898,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04315",
+"gene_reaction_rule":"WP_049586246.1",
 "annotation":{
 "ec-code":"2.7.1.11",
 "kegg.orthology":[
@@ -24922,7 +24922,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17430",
+"gene_reaction_rule":"WP_049588791.1",
 "annotation":{
 "bigg.reaction":[
 "U58",
@@ -24954,7 +24954,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06155",
+"gene_reaction_rule":"WP_049586630.1",
 "annotation":{
 "ec-code":"2.7.8.8",
 "metanetx.reaction":"MNXR136226",
@@ -24974,7 +24974,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10875 and TK37_RS08230 and TK37_RS09355 and TK37_RS20075 and TK37_RS17090 and TK37_RS04250 and TK37_RS08845 and TK37_RS18115 and TK37_RS09010",
+"gene_reaction_rule":"WP_014947786.1 and WP_049587019.1 and WP_049587262.1 and WP_049589161.1 and WP_014949232.1 and WP_039227752.1 and WP_049587138.1 and WP_014976690.1 and WP_049587170.1",
 "annotation":{
 "bigg.reaction":"ACOAD5f",
 "ec-code":[
@@ -25007,7 +25007,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04095 and TK37_RS14380",
+"gene_reaction_rule":"WP_049586202.1 and WP_049588338.1",
 "annotation":{
 "bigg.reaction":[
 "NTD9pp",
@@ -25048,7 +25048,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12580 and TK37_RS18250",
+"gene_reaction_rule":"WP_049587985.1 and WP_049588899.1",
 "annotation":{
 "bigg.reaction":"TDPGDH",
 "biocyc":"META:DTDPGLUCDEHYDRAT-RXN",
@@ -25073,7 +25073,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06740",
+"gene_reaction_rule":"WP_049586742.1",
 "annotation":{
 "bigg.reaction":[
 "FLVRx",
@@ -25110,7 +25110,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1E181pp",
 "ec-code":"3.1.1.5",
@@ -25131,7 +25131,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10990",
+"gene_reaction_rule":"WP_014949855.1",
 "annotation":{
 "ec-code":"2.7.1.40",
 "kegg.reaction":"R00659",
@@ -25154,7 +25154,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15745 or (TK37_RS09780 and TK37_RS13445 and TK37_RS18295 and TK37_RS07135 and TK37_RS17935)",
+"gene_reaction_rule":"WP_049588588.1 or (WP_049587342.1 and WP_014977336.1 and WP_049588907.1 and WP_049586860.1 and WP_049588854.1)",
 "annotation":{
 "bigg.reaction":[
 "ACALD",
@@ -25188,7 +25188,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02785",
+"gene_reaction_rule":"WP_049585984.1",
 "annotation":{
 "bigg.reaction":[
 "DXPRIi",
@@ -25215,7 +25215,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03400",
+"gene_reaction_rule":"WP_049586069.1",
 "annotation":{
 "biocyc":"META:RXN-13680",
 "ec-code":"3.5.1.15",
@@ -25236,7 +25236,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05595 or (TK37_RS15255 and TK37_RS01710 and TK37_RS17085) or TK37_RS17085",
+"gene_reaction_rule":"WP_049586525.1 or (WP_024015658.1 and WP_049585851.1 and WP_049588755.1) or WP_049588755.1",
 "annotation":{
 "bigg.reaction":[
 "ERG10",
@@ -25276,7 +25276,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04040",
+"gene_reaction_rule":"WP_049586187.1",
 "annotation":{
 "bigg.reaction":"SELMETAT",
 "ec-code":"2.5.1.6",
@@ -25300,7 +25300,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05170",
+"gene_reaction_rule":"WP_039228851.1",
 "annotation":{
 "bigg.reaction":[
 "ORPT",
@@ -25330,7 +25330,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560 or TK37_RS02805",
+"gene_reaction_rule":"WP_014949559.1 or WP_014948562.1",
 "annotation":{
 "bigg.reaction":"HBUHL1",
 "ec-code":"4.2.1.59",
@@ -25360,7 +25360,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17260 or TK37_RS00735 or TK37_RS04220",
+"gene_reaction_rule":"WP_014951061.1 or WP_049585624.1 or WP_049586232.1",
 "annotation":{
 "ec-code":"3.5.4.16",
 "kegg.orthology":[
@@ -25388,7 +25388,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06150",
+"gene_reaction_rule":"WP_049586628.1",
 "annotation":{
 "bigg.reaction":[
 "LEUabcpp",
@@ -25415,7 +25415,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08530",
+"gene_reaction_rule":"WP_049587083.1",
 "annotation":{
 "bigg.reaction":[
 "FBP",
@@ -25452,7 +25452,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03655",
+"gene_reaction_rule":"WP_049586129.1",
 "annotation":{
 "bigg.reaction":"THPDH",
 "ec-code":"1.1.1.262",
@@ -25475,7 +25475,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01435",
+"gene_reaction_rule":"WP_049585822.1",
 "annotation":{
 "bigg.reaction":[
 "THMDt2r",
@@ -25505,7 +25505,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17600 and TK37_RS14480",
+"gene_reaction_rule":"WP_014950684.1 and WP_049588355.1",
 "annotation":{
 "bigg.reaction":[
 "ALD2",
@@ -25549,7 +25549,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15735",
+"gene_reaction_rule":"WP_049588587.1",
 "annotation":{
 "bigg.reaction":"4OD",
 "ec-code":"4.1.1.77",
@@ -25573,7 +25573,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07145",
+"gene_reaction_rule":"WP_014948959.1",
 "annotation":{
 "ec-code":"2.7.1.23",
 "metanetx.reaction":"MNXR142368",
@@ -25593,7 +25593,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16705 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715",
+"gene_reaction_rule":"WP_049588707.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1",
 "annotation":{
 "bigg.reaction":[
 "3H2MBCOAD",
@@ -25632,7 +25632,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07225 and TK37_RS07220",
+"gene_reaction_rule":"WP_049586830.1 and WP_049586828.1",
 "annotation":{
 "bigg.reaction":[
 "ANS",
@@ -25668,7 +25668,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02630",
+"gene_reaction_rule":"WP_014948529.1",
 "annotation":{
 "ec-code":"2.7.8.-",
 "metanetx.reaction":"MNXR136303",
@@ -25687,7 +25687,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02750 or (TK37_RS13980 and TK37_RS20685) or (TK37_RS04495 and TK37_RS07675) or TK37_RS05630 or TK37_RS18985 or TK37_RS05630",
+"gene_reaction_rule":"WP_049585982.1 or (WP_014999437.1 and WP_053103828.1) or (WP_049586284.1 and WP_080986400.1) or WP_049586533.1 or WP_049589000.1 or WP_049586533.1",
 "annotation":{
 "bigg.reaction":"MEAMP1(gly-pro-L)",
 "metanetx.reaction":"MNXR137142",
@@ -25707,7 +25707,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10990",
+"gene_reaction_rule":"WP_014949855.1",
 "annotation":{
 "ec-code":"2.7.1.40",
 "kegg.orthology":[
@@ -25733,7 +25733,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06025",
+"gene_reaction_rule":"WP_049586604.1",
 "annotation":{
 "bigg.reaction":[
 "PGPP161",
@@ -25756,7 +25756,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04095 and TK37_RS14380",
+"gene_reaction_rule":"WP_049586202.1 and WP_049588338.1",
 "annotation":{
 "bigg.reaction":[
 "NTD8pp",
@@ -25796,7 +25796,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08435 and TK37_RS11220 and TK37_RS11660 and TK37_RS03755 and TK37_RS18545",
+"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
 "annotation":{
 "ec-code":"6.2.1.3",
 "metanetx.reaction":"MNXR134816",
@@ -25816,7 +25816,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14255",
+"gene_reaction_rule":"WP_049588317.1",
 "annotation":{
 "bigg.reaction":"G3PD2",
 "biocyc":"META:GLYC3PDEHYDROGBIOSYN-RXN",
@@ -25846,7 +25846,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16985",
+"gene_reaction_rule":"WP_014949212.1",
 "annotation":{
 "bigg.reaction":"KAS15",
 "biocyc":"META:2.3.1.180-RXN",
@@ -25879,7 +25879,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12305",
+"gene_reaction_rule":"WP_049587892.1",
 "annotation":{
 "bigg.reaction":[
 "CGLYabcpp",
@@ -25907,7 +25907,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2E160",
 "ec-code":"3.1.1.5",
@@ -25928,7 +25928,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16995",
+"gene_reaction_rule":"WP_014976326.1",
 "annotation":{
 "ec-code":"1.1.1.100",
 "metanetx.reaction":"MNXR134956",
@@ -25945,7 +25945,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07115",
+"gene_reaction_rule":"WP_049586804.1",
 "annotation":{
 "metanetx.reaction":"MNXR131363",
 "sbo":"SBO:0000655",
@@ -25964,7 +25964,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16145",
+"gene_reaction_rule":"WP_049588648.1",
 "annotation":{
 "biocyc":"META:HISTOLDEHYD-RXN",
 "ec-code":"1.1.1.23",
@@ -25994,7 +25994,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00210 or TK37_RS00210",
+"gene_reaction_rule":"WP_014951296.1 or WP_014951296.1",
 "annotation":{
 "bigg.reaction":"PRKIN",
 "biocyc":"META:PHOSPHORIBULOKINASE-RXN",
@@ -26019,7 +26019,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02780",
+"gene_reaction_rule":"WP_014948557.1",
 "annotation":{
 "ec-code":"2.7.7.41",
 "metanetx.reaction":"MNXR136218",
@@ -26038,7 +26038,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13780",
+"gene_reaction_rule":"WP_049588224.1",
 "annotation":{
 "ec-code":"2.7.8.5",
 "metanetx.reaction":"MNXR136259",
@@ -26057,7 +26057,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14500 and TK37_RS19730 and TK37_RS17765 and TK37_RS18690",
+"gene_reaction_rule":"WP_049588360.1 and WP_049589086.1 and WP_049588843.1 and WP_014976719.1",
 "annotation":{
 "ec-code":"2.3.2.2",
 "kegg.orthology":[
@@ -26079,7 +26079,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06490 and TK37_RS15450",
+"gene_reaction_rule":"WP_049586704.1 and WP_014948004.1",
 "annotation":{
 "bigg.reaction":[
 "MEP1",
@@ -26119,7 +26119,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1G161pp",
 "ec-code":"3.1.1.5",
@@ -26144,7 +26144,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18475 or TK37_RS18475",
+"gene_reaction_rule":"WP_049588929.1 or WP_049588929.1",
 "annotation":{
 "bigg.reaction":[
 "GUA1",
@@ -26177,7 +26177,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14510 and TK37_RS05455",
+"gene_reaction_rule":"WP_049588363.1 and WP_049586557.1",
 "annotation":{
 "bigg.reaction":"AGM4PH",
 "metanetx.reaction":"MNXR95548",
@@ -26197,7 +26197,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2G120",
 "ec-code":"3.1.1.5",
@@ -26219,7 +26219,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06005 and TK37_RS08655",
+"gene_reaction_rule":"WP_014950089.1 and WP_049587102.1",
 "annotation":{
 "bigg.reaction":[
 "RIB1",
@@ -26256,7 +26256,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04430",
+"gene_reaction_rule":"WP_049586270.1",
 "annotation":{
 "ec-code":"2.3.1.168",
 "kegg.orthology":"K09699",
@@ -26281,7 +26281,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS19095 and TK37_RS17645 and TK37_RS15160) or (TK37_RS19095 and TK37_RS17645 and TK37_RS15160)",
+"gene_reaction_rule":"(WP_039227034.1 and WP_015068029.1 and WP_049588512.1) or (WP_039227034.1 and WP_015068029.1 and WP_049588512.1)",
 "annotation":{
 "bigg.reaction":[
 "L-LACD2",
@@ -26305,7 +26305,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17425",
+"gene_reaction_rule":"WP_014978916.1",
 "annotation":{
 "biocyc":"META:RXN-10815",
 "ec-code":"1.13.11.27",
@@ -26337,7 +26337,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12310 and TK37_RS12300",
+"gene_reaction_rule":"WP_049587894.1 and WP_049587891.1",
 "annotation":{
 "bigg.reaction":[
 "NI2uabcpp",
@@ -26369,7 +26369,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1A160pp",
 "ec-code":"3.1.1.5",
@@ -26389,7 +26389,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13255 and TK37_RS18655",
+"gene_reaction_rule":"WP_049588124.1 and WP_041693510.1",
 "annotation":{
 "bigg.reaction":[
 "SHSL2r",
@@ -26424,7 +26424,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560 or TK37_RS02805",
+"gene_reaction_rule":"WP_014949559.1 or WP_014948562.1",
 "annotation":{
 "bigg.reaction":"3HAD140",
 "biocyc":"META:RXN-9537",
@@ -26457,7 +26457,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17260 or TK37_RS00735",
+"gene_reaction_rule":"WP_014951061.1 or WP_049585624.1",
 "annotation":{
 "ec-code":"3.5.4.16",
 "kegg.orthology":[
@@ -26482,7 +26482,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14890",
+"gene_reaction_rule":"WP_014951390.1",
 "annotation":{
 "bigg.reaction":"G3PAT180",
 "ec-code":"2.3.1.15",
@@ -26502,7 +26502,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10360 and TK37_RS13625",
+"gene_reaction_rule":"WP_015066029.1 and WP_014976618.1",
 "annotation":{
 "ec-code":"2.7.1.107",
 "metanetx.reaction":"MNXR136252",
@@ -26523,7 +26523,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13110",
+"gene_reaction_rule":"WP_049588091.1",
 "annotation":{
 "bigg.reaction":[
 "MCITS",
@@ -26556,7 +26556,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07955",
+"gene_reaction_rule":"WP_014950808.1",
 "annotation":{
 "ec-code":"2.7.1.48",
 "kegg.reaction":"R02097",
@@ -26580,7 +26580,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14220",
+"gene_reaction_rule":"WP_049588313.1",
 "annotation":{
 "bigg.reaction":[
 "GPDDA1pp",
@@ -26620,7 +26620,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17755 and TK37_RS04455",
+"gene_reaction_rule":"WP_049588842.1 and WP_049586277.1",
 "annotation":{
 "bigg.reaction":[
 "YFL030W",
@@ -26655,7 +26655,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02630",
+"gene_reaction_rule":"WP_014948529.1",
 "annotation":{
 "ec-code":"2.7.8.-",
 "metanetx.reaction":"MNXR136310",
@@ -26674,7 +26674,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13780",
+"gene_reaction_rule":"WP_049588224.1",
 "annotation":{
 "bigg.reaction":"PGSA160",
 "ec-code":"2.7.8.5",
@@ -26698,7 +26698,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13255 and TK37_RS18655",
+"gene_reaction_rule":"WP_049588124.1 and WP_041693510.1",
 "annotation":{
 "kegg.orthology":[
 "K01739",
@@ -26724,7 +26724,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04785 or TK37_RS04780",
+"gene_reaction_rule":"WP_014947725.1 or WP_014947726.1",
 "annotation":{
 "bigg.reaction":[
 "Kt6",
@@ -26754,7 +26754,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16985 or TK37_RS11900 or TK37_RS17005",
+"gene_reaction_rule":"WP_014949212.1 or WP_014949953.1 or WP_049588746.1",
 "annotation":{
 "bigg.reaction":[
 "CEM1_5",
@@ -26790,7 +26790,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18685 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715 and TK37_RS11765 and TK37_RS01845",
+"gene_reaction_rule":"WP_049588954.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1 and WP_014976911.1 and WP_014948837.1",
 "annotation":{
 "bigg.reaction":[
 "ECOAH4p",
@@ -26830,7 +26830,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01150 and TK37_RS16300",
+"gene_reaction_rule":"WP_049585726.1 and WP_014949647.1",
 "annotation":{
 "ec-code":"2.1.1.64",
 "kegg.reaction":"R05614",
@@ -26850,7 +26850,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05575",
+"gene_reaction_rule":"WP_049586519.1",
 "annotation":{
 "bigg.reaction":[
 "MGCOAH",
@@ -26880,7 +26880,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18435",
+"gene_reaction_rule":"WP_014950149.1",
 "annotation":{
 "bigg.reaction":[
 "ADE3_1",
@@ -26916,7 +26916,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16990",
+"gene_reaction_rule":"WP_049588745.1",
 "annotation":{
 "bigg.reaction":"FAS1_7_c",
 "kegg.orthology":[
@@ -26940,7 +26940,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10360 and TK37_RS13625",
+"gene_reaction_rule":"WP_015066029.1 and WP_014976618.1",
 "annotation":{
 "bigg.reaction":"DAGK181",
 "ec-code":"2.7.1.107",
@@ -26960,7 +26960,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03905",
+"gene_reaction_rule":"WP_049586167.1",
 "annotation":{
 "bigg.reaction":"KDOPP",
 "biocyc":"META:KDO-8PPHOSPHAT-RXN",
@@ -26990,7 +26990,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10360 and TK37_RS13625",
+"gene_reaction_rule":"WP_015066029.1 and WP_014976618.1",
 "annotation":{
 "bigg.reaction":"DAGK160",
 "ec-code":"2.7.1.107",
@@ -27009,7 +27009,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18685 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715 and TK37_RS11765 and TK37_RS01845",
+"gene_reaction_rule":"WP_049588954.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1 and WP_014976911.1 and WP_014948837.1",
 "annotation":{
 "bigg.reaction":[
 "ECOAH5",
@@ -27048,7 +27048,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04240",
+"gene_reaction_rule":"WP_039227754.1",
 "annotation":{
 "bigg.reaction":[
 "TRSARr",
@@ -27080,7 +27080,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13400",
+"gene_reaction_rule":"WP_049588165.1",
 "annotation":{
 "bigg.reaction":[
 "GLYCt",
@@ -27107,7 +27107,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02750 or (TK37_RS13980 and TK37_RS20685) or (TK37_RS04495 and TK37_RS07675) or TK37_RS05630 or TK37_RS18985 or TK37_RS05630",
+"gene_reaction_rule":"WP_049585982.1 or (WP_014999437.1 and WP_053103828.1) or (WP_049586284.1 and WP_080986400.1) or WP_049586533.1 or WP_049589000.1 or WP_049586533.1",
 "annotation":{
 "ec-code":"3.4.11.2",
 "metanetx.reaction":"MNXR129847",
@@ -27126,7 +27126,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13780",
+"gene_reaction_rule":"WP_049588224.1",
 "annotation":{
 "bigg.reaction":"PGSA181",
 "ec-code":"2.7.8.5",
@@ -27146,7 +27146,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09770",
+"gene_reaction_rule":"WP_049587341.1",
 "annotation":{
 "bigg.reaction":[
 "PROD2",
@@ -27178,7 +27178,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2A180",
 "ec-code":"3.1.1.5",
@@ -27199,7 +27199,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02775",
+"gene_reaction_rule":"WP_080986374.1",
 "annotation":{
 "ec-code":[
 "2.5.1.31",
@@ -27226,7 +27226,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14890",
+"gene_reaction_rule":"WP_014951390.1",
 "annotation":{
 "ec-code":"2.3.1.15",
 "metanetx.reaction":"MNXR136205",
@@ -27247,7 +27247,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16985 or TK37_RS11900 or TK37_RS17005",
+"gene_reaction_rule":"WP_014949212.1 or WP_014949953.1 or WP_049588746.1",
 "annotation":{
 "bigg.reaction":[
 "MCMAT6",
@@ -27286,7 +27286,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17530 and TK37_RS12285 and TK37_RS17535",
+"gene_reaction_rule":"WP_049588804.1 and WP_049587884.1 and WP_049588805.1",
 "annotation":{
 "bigg.reaction":[
 "XAND",
@@ -27325,7 +27325,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12600",
+"gene_reaction_rule":"WP_049587992.1",
 "annotation":{
 "bigg.reaction":[
 "ICL1",
@@ -27353,7 +27353,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15280",
+"gene_reaction_rule":"WP_014948150.1",
 "annotation":{
 "bigg.reaction":"HEXTT",
 "ec-code":[
@@ -27378,7 +27378,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17220",
+"gene_reaction_rule":"WP_014951053.1",
 "annotation":{
 "bigg.reaction":[
 "DHORTSn",
@@ -27409,7 +27409,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09195",
+"gene_reaction_rule":"WP_049587218.1",
 "annotation":{
 "bigg.reaction":[
 "MET6",
@@ -27440,7 +27440,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14890",
+"gene_reaction_rule":"WP_014951390.1",
 "annotation":{
 "biocyc":"META:RXN-1381",
 "ec-code":"2.3.1.15",
@@ -27462,7 +27462,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06065",
+"gene_reaction_rule":"WP_049586608.1",
 "annotation":{
 "bigg.reaction":"AACTOOR",
 "biocyc":"META:AMACETOXID-RXN",
@@ -27497,7 +27497,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS04110 and TK37_RS08380 and TK37_RS04115 and TK37_RS04120) or (TK37_RS04545 and TK37_RS08185 and TK37_RS07295 and TK37_RS18925 and TK37_RS08785 and TK37_RS17185 and TK37_RS11370 and TK37_RS02610 and TK37_RS02215 and TK37_RS00935 and TK37_RS12630 and TK37_RS06390 and TK37_RS12310 and TK37_RS18275)",
+"gene_reaction_rule":"(WP_049586203.1 and WP_080986402.1 and WP_049586204.1 and WP_049586205.1) or (WP_049586295.1 and WP_049587007.1 and WP_039225748.1 and WP_049588994.1 and WP_039226913.1 and WP_014980522.1 and WP_039233285.1 and WP_039230569.1 and WP_049585907.1 and WP_080986363.1 and WP_049587998.1 and WP_049586686.1 and WP_049587894.1 and WP_049588904.1)",
 "annotation":{
 "bigg.reaction":[
 "PIabc",
@@ -27528,7 +27528,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15965",
+"gene_reaction_rule":"WP_014949449.1",
 "annotation":{
 "bigg.reaction":[
 "AKGDb",
@@ -27562,7 +27562,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03050",
+"gene_reaction_rule":"WP_049586022.1",
 "annotation":{
 "bigg.reaction":[
 "HSDx",
@@ -27596,7 +27596,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS20050 and TK37_RS02040",
+"gene_reaction_rule":"WP_049589153.1 and WP_014948878.1",
 "annotation":{
 "bigg.reaction":[
 "ASAD",
@@ -27625,7 +27625,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14380",
+"gene_reaction_rule":"WP_049588338.1",
 "annotation":{
 "bigg.reaction":[
 "GTPDPDP",
@@ -27663,7 +27663,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19395 and TK37_RS07925",
+"gene_reaction_rule":"WP_014950978.1 and WP_014950802.1",
 "annotation":{
 "bigg.reaction":[
 "MDH1",
@@ -27705,7 +27705,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS19095 and TK37_RS17645 and TK37_RS15160) or (TK37_RS19095 and TK37_RS17645 and TK37_RS15160)",
+"gene_reaction_rule":"(WP_039227034.1 and WP_015068029.1 and WP_049588512.1) or (WP_039227034.1 and WP_015068029.1 and WP_049588512.1)",
 "annotation":{
 "bigg.reaction":"LDH_L",
 "biocyc":"META:L-LACTATE-DEHYDROGENASE-RXN",
@@ -27730,7 +27730,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2E181",
 "ec-code":"3.1.1.5",
@@ -27751,7 +27751,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07955",
+"gene_reaction_rule":"WP_014950808.1",
 "annotation":{
 "bigg.reaction":"CYTDK3",
 "ec-code":"2.7.1.48",
@@ -27773,7 +27773,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07955",
+"gene_reaction_rule":"WP_014950808.1",
 "annotation":{
 "bigg.reaction":[
 "URK1_2",
@@ -27803,7 +27803,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04095 and TK37_RS14380",
+"gene_reaction_rule":"WP_049586202.1 and WP_049588338.1",
 "annotation":{
 "bigg.reaction":[
 "U34",
@@ -27842,7 +27842,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13105",
+"gene_reaction_rule":"WP_049588089.1",
 "annotation":{
 "bigg.reaction":[
 "MCITL2m",
@@ -27877,7 +27877,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04425 and TK37_RS04420",
+"gene_reaction_rule":"WP_049586269.1 and WP_049586267.1",
 "annotation":{
 "ec-code":"1.2.4.4",
 "kegg.orthology":[
@@ -27906,7 +27906,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01855",
+"gene_reaction_rule":"WP_014976023.1",
 "annotation":{
 "bigg.reaction":[
 "TYR1",
@@ -27934,7 +27934,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05780",
+"gene_reaction_rule":"WP_014950132.1",
 "annotation":{
 "bigg.reaction":[
 "RBFKm",
@@ -27968,7 +27968,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16735",
+"gene_reaction_rule":"WP_080986462.1",
 "annotation":{
 "bigg.reaction":"TPI",
 "biocyc":"META:TRIOSEPISOMERIZATION-RXN",
@@ -27991,7 +27991,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04060",
+"gene_reaction_rule":"WP_049586194.1",
 "annotation":{
 "bigg.reaction":"FBA3",
 "biocyc":"META:SEDOBISALDOL-RXN",
@@ -28023,7 +28023,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04710",
+"gene_reaction_rule":"WP_080986386.1",
 "annotation":{
 "ec-code":"2.7.8.12",
 "metanetx.reaction":"MNXR136288",
@@ -28045,7 +28045,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13910",
+"gene_reaction_rule":"WP_014980177.1",
 "annotation":{
 "bigg.reaction":"GLNSP1",
 "ec-code":"6.3.1.2",
@@ -28065,7 +28065,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14120",
+"gene_reaction_rule":"WP_039225046.1",
 "annotation":{
 "bigg.reaction":[
 "PPBNGS",
@@ -28092,7 +28092,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02830 and TK37_RS20110",
+"gene_reaction_rule":"WP_049585989.1 and WP_014949945.1",
 "annotation":{
 "ec-code":"6.4.1.2",
 "kegg.orthology":[
@@ -28121,7 +28121,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18460",
+"gene_reaction_rule":"WP_039228347.1",
 "annotation":{
 "bigg.reaction":"PLIPA1A180pp",
 "ec-code":"3.1.1.32",
@@ -28141,7 +28141,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02750 or (TK37_RS13980 and TK37_RS20685) or (TK37_RS04495 and TK37_RS07675) or TK37_RS05630 or TK37_RS18985 or TK37_RS05630",
+"gene_reaction_rule":"WP_049585982.1 or (WP_014999437.1 and WP_053103828.1) or (WP_049586284.1 and WP_080986400.1) or WP_049586533.1 or WP_049589000.1 or WP_049586533.1",
 "annotation":{
 "bigg.reaction":"MEAMP1(gly-gln)",
 "biocyc":"META:RXN0-6983",
@@ -28164,7 +28164,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16705 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715",
+"gene_reaction_rule":"WP_049588707.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1",
 "annotation":{
 "bigg.reaction":[
 "HACD6",
@@ -28202,7 +28202,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17275",
+"gene_reaction_rule":"WP_039229281.1",
 "annotation":{
 "ec-code":"3.5.1.4",
 "kegg.orthology":"K01426",
@@ -28225,7 +28225,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16445",
+"gene_reaction_rule":"WP_049588677.1",
 "annotation":{
 "bigg.reaction":[
 "APSPTi",
@@ -28250,7 +28250,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10735",
+"gene_reaction_rule":"WP_014947760.1",
 "annotation":{
 "bigg.reaction":[
 "U95",
@@ -28291,7 +28291,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01435",
+"gene_reaction_rule":"WP_049585822.1",
 "annotation":{
 "bigg.reaction":[
 "U188",
@@ -28318,7 +28318,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04710",
+"gene_reaction_rule":"WP_080986386.1",
 "annotation":{
 "ec-code":"2.7.8.12",
 "metanetx.reaction":"MNXR136287",
@@ -28338,7 +28338,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13225 or TK37_RS13225",
+"gene_reaction_rule":"WP_049588115.1 or WP_049588115.1",
 "annotation":{
 "bigg.reaction":"ANHMK",
 "metanetx.reaction":"MNXR95840",
@@ -28356,7 +28356,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16115 and TK37_RS11110",
+"gene_reaction_rule":"WP_049588642.1 and WP_049587613.1",
 "annotation":{
 "bigg.reaction":[
 "HIS4_2",
@@ -28389,7 +28389,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11020 and TK37_RS19130",
+"gene_reaction_rule":"WP_014949849.1 and WP_014979614.1",
 "annotation":{
 "bigg.reaction":"EDA",
 "biocyc":"META:KDPGALDOL-RXN",
@@ -28424,7 +28424,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09630 and TK37_RS08150",
+"gene_reaction_rule":"WP_049587320.1 and WP_049586999.1",
 "annotation":{
 "bigg.reaction":"SHCHD2",
 "biocyc":"META:DIMETHUROPORDEHYDROG-RXN",
@@ -28452,7 +28452,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18235",
+"gene_reaction_rule":"WP_049588896.1",
 "annotation":{
 "bigg.reaction":[
 "G1PTT",
@@ -28487,7 +28487,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2E140",
 "ec-code":"3.1.1.5",
@@ -28507,7 +28507,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15645",
+"gene_reaction_rule":"WP_049588570.1",
 "annotation":{
 "bigg.reaction":[
 "BAT1_2",
@@ -28535,7 +28535,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560 or TK37_RS02805",
+"gene_reaction_rule":"WP_014949559.1 or WP_014948562.1",
 "annotation":{
 "ec-code":"4.2.1.0",
 "metanetx.reaction":"MNXR134895",
@@ -28556,7 +28556,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11415",
+"gene_reaction_rule":"WP_014948685.1",
 "annotation":{
 "bigg.reaction":[
 "PHETHPTOX",
@@ -28588,7 +28588,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08900",
+"gene_reaction_rule":"WP_014950281.1",
 "annotation":{
 "bigg.reaction":"BETALDHy",
 "ec-code":"1.2.1.8",
@@ -28613,7 +28613,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18685 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715 and TK37_RS11765 and TK37_RS01845",
+"gene_reaction_rule":"WP_049588954.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1 and WP_014976911.1 and WP_014948837.1",
 "annotation":{
 "bigg.reaction":[
 "ECOAH7p",
@@ -28653,7 +28653,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08840",
+"gene_reaction_rule":"WP_039236747.1",
 "annotation":{
 "bigg.reaction":[
 "GUK1_3",
@@ -28677,7 +28677,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06900 and TK37_RS03730",
+"gene_reaction_rule":"WP_014950960.1 and WP_080986381.1",
 "annotation":{
 "bigg.reaction":[
 "HMG1",
@@ -28709,7 +28709,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00560",
+"gene_reaction_rule":"WP_014951234.1",
 "annotation":{
 "bigg.reaction":[
 "GFA1",
@@ -28740,7 +28740,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14860 or TK37_RS14860 or TK37_RS14860",
+"gene_reaction_rule":"WP_014951396.1 or WP_014951396.1 or WP_014951396.1",
 "annotation":{
 "ec-code":"1.1.1.86",
 "kegg.orthology":"K00053",
@@ -28766,7 +28766,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06010",
+"gene_reaction_rule":"WP_014950088.1",
 "annotation":{
 "bigg.reaction":"RIB5",
 "biocyc":"META:LUMAZINESYN-RXN",
@@ -28790,7 +28790,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14210",
+"gene_reaction_rule":"WP_014948076.1",
 "annotation":{
 "ec-code":"4.1.1.65",
 "metanetx.reaction":"MNXR136233",
@@ -28809,7 +28809,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00600 and TK37_RS13175",
+"gene_reaction_rule":"WP_049585588.1 and WP_014950548.1",
 "annotation":{
 "bigg.reaction":"AHCYSNS",
 "biocyc":"META:ADENOSYLHOMOCYSTEINE-NUCLEOSIDASE-RXN",
@@ -28839,7 +28839,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02750 or (TK37_RS13980 and TK37_RS20685) or (TK37_RS04495 and TK37_RS07675) or TK37_RS05630 or TK37_RS18985 or TK37_RS05630",
+"gene_reaction_rule":"WP_049585982.1 or (WP_014999437.1 and WP_053103828.1) or (WP_049586284.1 and WP_080986400.1) or WP_049586533.1 or WP_049589000.1 or WP_049586533.1",
 "annotation":{
 "bigg.reaction":"MEAMP1(ala-thr)",
 "metanetx.reaction":"MNXR137144",
@@ -28861,7 +28861,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06450",
+"gene_reaction_rule":"WP_049586697.1",
 "annotation":{
 "bigg.reaction":"PPS",
 "biocyc":"META:PEPSYNTH-RXN",
@@ -28887,7 +28887,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560",
+"gene_reaction_rule":"WP_014949559.1",
 "annotation":{
 "ec-code":"4.2.1.0",
 "metanetx.reaction":"MNXR134862",
@@ -28906,7 +28906,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09465",
+"gene_reaction_rule":"WP_049587284.1",
 "annotation":{
 "bigg.reaction":"ALATA_D",
 "biocyc":"META:D-ALANINE-AMINOTRANSFERASE-RXN",
@@ -28929,7 +28929,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14885",
+"gene_reaction_rule":"WP_014977809.1",
 "annotation":{
 "bigg.reaction":[
 "CHA1_1",
@@ -28966,7 +28966,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2E180",
 "ec-code":"3.1.1.5",
@@ -28984,7 +28984,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01860 and TK37_RS15835) or (TK37_RS01860 and TK37_RS01855)",
+"gene_reaction_rule":"(WP_049585865.1 and WP_049588605.1) or (WP_049585865.1 and WP_014976023.1)",
 "annotation":{
 "bigg.reaction":[
 "ARO7",
@@ -29021,7 +29021,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02645",
+"gene_reaction_rule":"WP_014975843.1",
 "annotation":{
 "bigg.reaction":[
 "GALUi",
@@ -29061,7 +29061,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01435",
+"gene_reaction_rule":"WP_049585822.1",
 "annotation":{
 "bigg.reaction":[
 "FUI1_3",
@@ -29089,7 +29089,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00590",
+"gene_reaction_rule":"WP_049585748.1",
 "annotation":{
 "bigg.reaction":"HDCAt2",
 "metanetx.reaction":"MNXR100583",
@@ -29106,7 +29106,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19745",
+"gene_reaction_rule":"WP_014948008.1",
 "annotation":{
 "bigg.reaction":[
 "G1SAT",
@@ -29134,7 +29134,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03520",
+"gene_reaction_rule":"WP_049586099.1",
 "annotation":{
 "biocyc":"META:RIB5PISOM-RXN",
 "ec-code":"5.3.1.6",
@@ -29161,7 +29161,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04720 or TK37_RS04720",
+"gene_reaction_rule":"WP_039228930.1 or WP_039228930.1",
 "annotation":{
 "bigg.reaction":[
 "SHK3Dr",
@@ -29203,7 +29203,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13235",
+"gene_reaction_rule":"WP_049588118.1",
 "annotation":{
 "bigg.reaction":[
 "GLCt2",
@@ -29230,7 +29230,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07910",
+"gene_reaction_rule":"WP_049586958.1",
 "annotation":{
 "bigg.reaction":[
 "EAR100x",
@@ -29260,7 +29260,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07960",
+"gene_reaction_rule":"WP_014950809.1",
 "annotation":{
 "bigg.reaction":[
 "DCYTt2",
@@ -29286,7 +29286,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07400",
+"gene_reaction_rule":"WP_049586872.1",
 "annotation":{
 "biocyc":"META:RXN-9087",
 "ec-code":[
@@ -29320,7 +29320,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04315",
+"gene_reaction_rule":"WP_049586246.1",
 "annotation":{
 "biocyc":"META:TAGAKIN-RXN",
 "ec-code":[
@@ -29356,7 +29356,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1A180pp",
 "ec-code":"3.1.1.5",
@@ -29376,7 +29376,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17275",
+"gene_reaction_rule":"WP_039229281.1",
 "annotation":{
 "bigg.reaction":[
 "YMR293C",
@@ -29409,7 +29409,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07920",
+"gene_reaction_rule":"WP_049586959.1",
 "annotation":{
 "bigg.reaction":"PPC",
 "ec-code":"4.1.1.31",
@@ -29432,7 +29432,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03535",
+"gene_reaction_rule":"WP_014977204.1",
 "annotation":{
 "bigg.reaction":[
 "PNS4",
@@ -29466,7 +29466,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16035",
+"gene_reaction_rule":"WP_014950051.1",
 "annotation":{
 "bigg.reaction":[
 "APT2",
@@ -29500,7 +29500,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS20130",
+"gene_reaction_rule":"WP_014949941.1",
 "annotation":{
 "bigg.reaction":[
 "ADE4",
@@ -29526,7 +29526,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09810",
+"gene_reaction_rule":"WP_049587347.1",
 "annotation":{
 "bigg.reaction":"MECDPS",
 "biocyc":"META:RXN0-302",
@@ -29555,7 +29555,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560 or TK37_RS02805",
+"gene_reaction_rule":"WP_014949559.1 or WP_014948562.1",
 "annotation":{
 "bigg.reaction":"3HAD121",
 "ec-code":"4.2.1.61",
@@ -29575,7 +29575,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12790",
+"gene_reaction_rule":"WP_049588021.1",
 "annotation":{
 "bigg.reaction":[
 "YNK1_8",
@@ -29612,7 +29612,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03720",
+"gene_reaction_rule":"WP_049586139.1",
 "annotation":{
 "bigg.reaction":"NTPP8",
 "biocyc":[
@@ -29651,7 +29651,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17755 and TK37_RS04455",
+"gene_reaction_rule":"WP_049588842.1 and WP_049586277.1",
 "annotation":{
 "bigg.reaction":"SPA",
 "biocyc":"META:SERINE--PYRUVATE-AMINOTRANSFERASE-RXN",
@@ -29679,7 +29679,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09735",
+"gene_reaction_rule":"WP_049587335.1",
 "annotation":{
 "bigg.reaction":"PPA2",
 "biocyc":"META:TRIPHOSPHATASE-RXN",
@@ -29706,7 +29706,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02780",
+"gene_reaction_rule":"WP_014948557.1",
 "annotation":{
 "bigg.reaction":"DASYN180",
 "ec-code":"2.7.7.41",
@@ -29725,7 +29725,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16125",
+"gene_reaction_rule":"WP_049588644.1",
 "annotation":{
 "bigg.reaction":[
 "PRMICI",
@@ -29758,7 +29758,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13780",
+"gene_reaction_rule":"WP_049588224.1",
 "annotation":{
 "ec-code":"2.7.8.5",
 "metanetx.reaction":"MNXR136260",
@@ -29775,7 +29775,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17260 or TK37_RS00735",
+"gene_reaction_rule":"WP_014951061.1 or WP_049585624.1",
 "annotation":{
 "ec-code":"3.5.4.16",
 "kegg.orthology":[
@@ -29801,7 +29801,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06155",
+"gene_reaction_rule":"WP_049586630.1",
 "annotation":{
 "ec-code":"2.7.8.8",
 "metanetx.reaction":"MNXR136223",
@@ -29821,7 +29821,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16995",
+"gene_reaction_rule":"WP_014976326.1",
 "annotation":{
 "bigg.reaction":[
 "3OAR160",
@@ -29853,7 +29853,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06155",
+"gene_reaction_rule":"WP_049586630.1",
 "annotation":{
 "bigg.reaction":"PSSA180",
 "ec-code":"2.7.8.8",
@@ -29873,7 +29873,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02295",
+"gene_reaction_rule":"WP_049585927.1",
 "annotation":{
 "bigg.reaction":[
 "AGDC_r",
@@ -29903,7 +29903,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11355",
+"gene_reaction_rule":"WP_049587668.1",
 "annotation":{
 "bigg.reaction":[
 "OAADC",
@@ -29939,7 +29939,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07350",
+"gene_reaction_rule":"WP_049586864.1",
 "annotation":{
 "biocyc":"META:3.1.4.14-RXN",
 "ec-code":"3.1.4.14",
@@ -29966,7 +29966,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15195 and TK37_RS19175",
+"gene_reaction_rule":"WP_049588500.1 and WP_014976831.1",
 "annotation":{
 "bigg.reaction":[
 "DKII",
@@ -29998,7 +29998,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15955 and TK37_RS15960",
+"gene_reaction_rule":"WP_012518366.1 and WP_014949450.1",
 "annotation":{
 "bigg.reaction":[
 "SUCOAS",
@@ -30033,7 +30033,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04525",
+"gene_reaction_rule":"WP_049586292.1",
 "annotation":{
 "bigg.reaction":[
 "GLUDx",
@@ -30074,7 +30074,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11890",
+"gene_reaction_rule":"WP_049587777.1",
 "annotation":{
 "ec-code":"1.1.3.9",
 "kegg.orthology":"K04618",
@@ -30096,7 +30096,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10770",
+"gene_reaction_rule":"WP_014947767.1",
 "annotation":{
 "bigg.reaction":[
 "TSULST",
@@ -30132,7 +30132,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19265",
+"gene_reaction_rule":"WP_080986475.1",
 "annotation":{
 "bigg.reaction":"IZPN",
 "biocyc":"META:IMIDAZOLONEPROPIONASE-RXN",
@@ -30159,7 +30159,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00085",
+"gene_reaction_rule":"WP_014951321.1",
 "annotation":{
 "bigg.reaction":[
 "NTD7pp",
@@ -30203,7 +30203,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11440",
+"gene_reaction_rule":"WP_049587678.1",
 "annotation":{
 "bigg.reaction":"VALDHr",
 "biocyc":"META:RXN-13184",
@@ -30235,7 +30235,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14525",
+"gene_reaction_rule":"WP_080986441.1",
 "annotation":{
 "bigg.reaction":"ACM6PH",
 "ec-code":"4.2.1.126",
@@ -30257,7 +30257,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12045 and TK37_RS16635",
+"gene_reaction_rule":"WP_049587825.1 and WP_014949348.1",
 "annotation":{
 "bigg.reaction":"MDDCP4pp",
 "ec-code":"3.4.16.4",
@@ -30278,7 +30278,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS20170",
+"gene_reaction_rule":"WP_039222269.1",
 "annotation":{
 "ec-code":[
 "6.3.4.10",
@@ -30312,7 +30312,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07955",
+"gene_reaction_rule":"WP_014950808.1",
 "annotation":{
 "ec-code":"2.7.1.48",
 "kegg.reaction":"R00967",
@@ -30332,7 +30332,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14660",
+"gene_reaction_rule":"WP_049588401.1",
 "annotation":{
 "bigg.reaction":"GLCS1",
 "ec-code":"2.4.1.21",
@@ -30353,7 +30353,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1G180pp",
 "ec-code":"3.1.1.5",
@@ -30376,7 +30376,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04040",
+"gene_reaction_rule":"WP_049586187.1",
 "annotation":{
 "bigg.reaction":[
 "SAM2",
@@ -30408,7 +30408,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08990",
+"gene_reaction_rule":"WP_014950261.1",
 "annotation":{
 "bigg.reaction":[
 "U15",
@@ -30440,7 +30440,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560",
+"gene_reaction_rule":"WP_014949559.1",
 "annotation":{
 "bigg.reaction":"3HAD181",
 "ec-code":"4.2.1.61",
@@ -30458,7 +30458,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18315",
+"gene_reaction_rule":"WP_049588908.1",
 "annotation":{
 "bigg.reaction":"HPYRI",
 "biocyc":"META:RXN0-305",
@@ -30482,7 +30482,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02750 or (TK37_RS13980 and TK37_RS20685) or (TK37_RS04495 and TK37_RS07675) or TK37_RS05630 or TK37_RS18985 or TK37_RS05630",
+"gene_reaction_rule":"WP_049585982.1 or (WP_014999437.1 and WP_053103828.1) or (WP_049586284.1 and WP_080986400.1) or WP_049586533.1 or WP_049589000.1 or WP_049586533.1",
 "annotation":{
 "ec-code":"3.4.11.2",
 "metanetx.reaction":"MNXR137157",
@@ -30502,7 +30502,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1A141pp",
 "ec-code":"3.1.1.5",
@@ -30523,7 +30523,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10790",
+"gene_reaction_rule":"WP_014975277.1",
 "annotation":{
 "bigg.reaction":[
 "SRT1",
@@ -30562,7 +30562,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06995 or TK37_RS06995",
+"gene_reaction_rule":"WP_049586782.1 or WP_049586782.1",
 "annotation":{
 "bigg.reaction":"ALPATE160pp",
 "metanetx.reaction":"MNXR95782",
@@ -30582,7 +30582,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02780",
+"gene_reaction_rule":"WP_014948557.1",
 "annotation":{
 "bigg.reaction":"DASYN120",
 "ec-code":"2.7.7.41",
@@ -30603,7 +30603,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2A161",
 "ec-code":"3.1.1.5",
@@ -30623,7 +30623,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01455 or TK37_RS03130",
+"gene_reaction_rule":"WP_014948764.1 or WP_049586032.1",
 "annotation":{
 "bigg.reaction":[
 "SODe",
@@ -30657,7 +30657,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560 or TK37_RS02805",
+"gene_reaction_rule":"WP_014949559.1 or WP_014948562.1",
 "annotation":{
 "ec-code":"4.2.1.0",
 "metanetx.reaction":"MNXR134878",
@@ -30676,7 +30676,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03465",
+"gene_reaction_rule":"WP_049586087.1",
 "annotation":{
 "bigg.reaction":[
 "LAT1",
@@ -30706,7 +30706,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16995",
+"gene_reaction_rule":"WP_014976326.1",
 "annotation":{
 "bigg.reaction":[
 "3OAR120",
@@ -30742,7 +30742,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04365 and TK37_RS04360",
+"gene_reaction_rule":"WP_049586255.1 and WP_049586254.1",
 "annotation":{
 "bigg.reaction":[
 "PCAIJ",
@@ -30775,7 +30775,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00515",
+"gene_reaction_rule":"WP_014951242.1",
 "annotation":{
 "bigg.reaction":[
 "ARGDCpp",
@@ -30809,7 +30809,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09325",
+"gene_reaction_rule":"WP_049587251.1",
 "annotation":{
 "bigg.reaction":"CPPPGO2",
 "biocyc":"META:HEMN-RXN",
@@ -30840,7 +30840,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17260 or TK37_RS00735",
+"gene_reaction_rule":"WP_014951061.1 or WP_049585624.1",
 "annotation":{
 "bigg.reaction":[
 "FOL2",
@@ -30871,7 +30871,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14890 and TK37_RS17000",
+"gene_reaction_rule":"WP_014951390.1 and WP_012518211.1",
 "annotation":{
 "bigg.reaction":"G3PAT120",
 "ec-code":"2.3.1.15",
@@ -30893,7 +30893,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17600 and TK37_RS14480",
+"gene_reaction_rule":"WP_014950684.1 and WP_049588355.1",
 "annotation":{
 "metanetx.reaction":"MNXR95752",
 "rhea":"16186",
@@ -30912,7 +30912,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09220",
+"gene_reaction_rule":"WP_049587293.1",
 "annotation":{
 "bigg.reaction":"VPAMT",
 "biocyc":"META:VALINE-PYRUVATE-AMINOTRANSFER-RXN",
@@ -30940,7 +30940,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10925",
+"gene_reaction_rule":"WP_049587570.1",
 "annotation":{
 "bigg.reaction":[
 "THI22",
@@ -30977,7 +30977,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00815",
+"gene_reaction_rule":"WP_049585647.1",
 "annotation":{
 "bigg.reaction":[
 "XYLt2",
@@ -30999,7 +30999,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07185",
+"gene_reaction_rule":"WP_049586820.1",
 "annotation":{
 "bigg.reaction":[
 "MALTATr",
@@ -31028,7 +31028,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS13980 and TK37_RS20685) or (TK37_RS04495 and TK37_RS07675) or TK37_RS18985",
+"gene_reaction_rule":"(WP_014999437.1 and WP_053103828.1) or (WP_049586284.1 and WP_080986400.1) or WP_049589000.1",
 "annotation":{
 "bigg.reaction":"MEAMP1(ala-gln)",
 "biocyc":"META:RXN0-6976",
@@ -31050,7 +31050,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02815",
+"gene_reaction_rule":"WP_049585987.1",
 "annotation":{
 "biocyc":"META:LIPIDADISACCHARIDESYNTH-RXN",
 "ec-code":"2.4.1.182",
@@ -31077,7 +31077,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01860 and TK37_RS15835) or (TK37_RS01860 and TK37_RS01855)",
+"gene_reaction_rule":"(WP_049585865.1 and WP_049588605.1) or (WP_049585865.1 and WP_014976023.1)",
 "annotation":{
 "bigg.reaction":[
 "PPNDH",
@@ -31115,7 +31115,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18640 and TK37_RS13800",
+"gene_reaction_rule":"WP_014949721.1 and WP_049588230.1",
 "annotation":{
 "bigg.reaction":[
 "ASPTA4",
@@ -31145,7 +31145,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06995 or TK37_RS06995",
+"gene_reaction_rule":"WP_049586782.1 or WP_049586782.1",
 "annotation":{
 "bigg.reaction":"ALPATG160pp",
 "metanetx.reaction":"MNXR135731",
@@ -31164,7 +31164,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04095 and TK37_RS14380",
+"gene_reaction_rule":"WP_049586202.1 and WP_049588338.1",
 "annotation":{
 "bigg.reaction":[
 "NTD4",
@@ -31211,7 +31211,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11035",
+"gene_reaction_rule":"WP_049587596.1",
 "annotation":{
 "bigg.reaction":[
 "MLTG1",
@@ -31276,7 +31276,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04240",
+"gene_reaction_rule":"WP_039227754.1",
 "annotation":{
 "biocyc":"META:TSA-REDUCT-RXN",
 "ec-code":"1.1.1.60",
@@ -31302,7 +31302,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02750 or (TK37_RS13980 and TK37_RS20685) or (TK37_RS04495 and TK37_RS07675) or TK37_RS05630 or TK37_RS18985 or TK37_RS05630",
+"gene_reaction_rule":"WP_049585982.1 or (WP_014999437.1 and WP_053103828.1) or (WP_049586284.1 and WP_080986400.1) or WP_049586533.1 or WP_049589000.1 or WP_049586533.1",
 "annotation":{
 "bigg.reaction":"MEAMP1(ala-leu)",
 "biocyc":"META:RXN0-6979",
@@ -31325,7 +31325,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07955",
+"gene_reaction_rule":"WP_014950808.1",
 "annotation":{
 "ec-code":"2.7.1.48",
 "kegg.reaction":"R02372",
@@ -31346,7 +31346,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04710",
+"gene_reaction_rule":"WP_080986386.1",
 "annotation":{
 "ec-code":"2.7.8.12",
 "metanetx.reaction":"MNXR136290",
@@ -31366,7 +31366,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03055",
+"gene_reaction_rule":"WP_014950486.1",
 "annotation":{
 "bigg.reaction":[
 "HSK",
@@ -31398,7 +31398,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17385 and TK37_RS07450",
+"gene_reaction_rule":"WP_014948020.1 and WP_049586880.1",
 "annotation":{
 "bigg.reaction":"AST",
 "biocyc":"META:ARGININE-N-SUCCINYLTRANSFERASE-RXN",
@@ -31423,7 +31423,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10990",
+"gene_reaction_rule":"WP_014949855.1",
 "annotation":{
 "ec-code":"2.7.1.40",
 "kegg.reaction":"R00572",
@@ -31442,7 +31442,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09555",
+"gene_reaction_rule":"WP_049587305.1",
 "annotation":{
 "bigg.reaction":"LYSAM",
 "biocyc":"META:LYSINE-23-AMINOMUTASE-RXN",
@@ -31468,7 +31468,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04060",
+"gene_reaction_rule":"WP_049586194.1",
 "annotation":{
 "bigg.reaction":"FBA",
 "ec-code":"4.1.2.13",
@@ -31498,7 +31498,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18815 and TK37_RS19920",
+"gene_reaction_rule":"WP_080986474.1 and WP_049589117.1",
 "annotation":{
 "bigg.reaction":[
 "ASPt2m",
@@ -31530,7 +31530,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14230",
+"gene_reaction_rule":"WP_049588315.1",
 "annotation":{
 "biocyc":[
 "META:NUCLEOSIDE-DIPHOSPHATASE-RXN",
@@ -31563,7 +31563,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17955",
+"gene_reaction_rule":"WP_049588856.1",
 "annotation":{
 "bigg.reaction":"CDPMEK",
 "biocyc":"META:2.7.1.148-RXN",
@@ -31590,7 +31590,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14210",
+"gene_reaction_rule":"WP_014948076.1",
 "annotation":{
 "bigg.reaction":"PSD120",
 "ec-code":"4.1.1.65",
@@ -31610,7 +31610,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04055",
+"gene_reaction_rule":"WP_049586192.1",
 "annotation":{
 "bigg.reaction":[
 "PGK1",
@@ -31643,7 +31643,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14475",
+"gene_reaction_rule":"WP_014948109.1",
 "annotation":{
 "bigg.reaction":[
 "ADSS_i",
@@ -31677,7 +31677,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11290 or TK37_RS11290",
+"gene_reaction_rule":"WP_014948664.1 or WP_014948664.1",
 "annotation":{
 "bigg.reaction":[
 "HCO3Em",
@@ -31722,7 +31722,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04095 and TK37_RS14380",
+"gene_reaction_rule":"WP_049586202.1 and WP_049588338.1",
 "annotation":{
 "bigg.reaction":[
 "NTD11",
@@ -31767,7 +31767,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11920 and TK37_RS14320",
+"gene_reaction_rule":"WP_049587792.1 and WP_014948054.1",
 "annotation":{
 "bigg.reaction":"MGSA",
 "biocyc":"META:METHGLYSYN-RXN",
@@ -31794,7 +31794,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09400",
+"gene_reaction_rule":"WP_049587269.1",
 "annotation":{
 "bigg.reaction":[
 "DGTPH",
@@ -31824,7 +31824,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02750 or (TK37_RS13980 and TK37_RS20685) or (TK37_RS04495 and TK37_RS07675) or TK37_RS05630 or TK37_RS18985 or TK37_RS05630",
+"gene_reaction_rule":"WP_049585982.1 or (WP_014999437.1 and WP_053103828.1) or (WP_049586284.1 and WP_080986400.1) or WP_049586533.1 or WP_049589000.1 or WP_049586533.1",
 "annotation":{
 "bigg.reaction":[
 "AMPEP10",
@@ -31846,7 +31846,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12720",
+"gene_reaction_rule":"WP_014950183.1",
 "annotation":{
 "bigg.reaction":[
 "INM1",
@@ -31882,7 +31882,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19140",
+"gene_reaction_rule":"WP_049589017.1",
 "annotation":{
 "bigg.reaction":"GUI2",
 "biocyc":"META:GALACTUROISOM-RXN",
@@ -31908,7 +31908,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01430",
+"gene_reaction_rule":"WP_039222880.1",
 "annotation":{
 "bigg.reaction":[
 "ARO2",
@@ -31937,7 +31937,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560 or TK37_RS02805",
+"gene_reaction_rule":"WP_014949559.1 or WP_014948562.1",
 "annotation":{
 "ec-code":"4.2.1.0",
 "metanetx.reaction":"MNXR134903",
@@ -31978,7 +31978,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06630 and TK37_RS17120 and TK37_RS15600 and TK37_RS10715 and TK37_RS17145 and TK37_RS17930 and TK37_RS15570 and TK37_RS00955 and TK37_RS06650 and TK37_RS05425 and TK37_RS04835 and TK37_RS17150 and TK37_RS01820 and TK37_RS00945 and TK37_RS02140 and TK37_RS15565 and TK37_RS15290 and TK37_RS15585 and TK37_RS03810 and TK37_RS16875 and TK37_RS06640 and TK37_RS18520 and TK37_RS20550 and TK37_RS04865 and TK37_RS19380 and TK37_RS13970 and TK37_RS10720 and TK37_RS08300 and TK37_RS06595 and TK37_RS06600 and TK37_RS06585 and TK37_RS13215 and TK37_RS05770 and TK37_RS03815 and TK37_RS17810 and TK37_RS06255 and TK37_RS15610 and TK37_RS20335 and TK37_RS05420 and TK37_RS06620 and TK37_RS16385 and TK37_RS01835 and TK37_RS04830 and TK37_RS05785 and TK37_RS16680 and TK37_RS15580 and TK37_RS15560 and TK37_RS02835 and TK37_RS01925 and TK37_RS07490 and TK37_RS06665 and TK37_RS04770 and TK37_RS11325 and TK37_RS17825 and TK37_RS06635 and TK37_RS06660 and TK37_RS06645 and TK37_RS06625 and TK37_RS15590 and TK37_RS06605 and TK37_RS06655 and TK37_RS01375 and TK37_RS02755 and TK37_RS15575 and TK37_RS00950 and TK37_RS01260 and TK37_RS17365 and TK37_RS06610 and TK37_RS20380 and TK37_RS16975 and TK37_RS15595 and TK37_RS17820 and TK37_RS17140 and TK37_RS07445 and TK37_RS17155 and TK37_RS15285 and TK37_RS17125 and TK37_RS15605",
+"gene_reaction_rule":"WP_012519221.1 and WP_014951036.1 and WP_012516958.1 and WP_014947757.1 and WP_014951041.1 and WP_014976150.1 and WP_014997065.1 and WP_012519953.1 and WP_014950910.1 and WP_049586479.1 and WP_049586364.1 and WP_014980521.1 and WP_014948832.1 and WP_014951120.1 and WP_049585896.1 and WP_014947980.1 and WP_012517170.1 and WP_012516961.1 and WP_014948329.1 and WP_049588729.1 and WP_014950909.1 and WP_080986471.1 and WP_049589231.1 and WP_014290886.1 and WP_014950975.1 and WP_049588258.1 and WP_012516577.1 and WP_012517258.1 and WP_012519214.1 and WP_012519215.1 and WP_012519212.1 and WP_014950559.1 and WP_014950134.1 and WP_014948330.1 and WP_049588849.1 and WP_012518257.1 and WP_010179497.1 and WP_049589203.1 and WP_012518127.1 and WP_049586735.1 and WP_014949630.1 and WP_024015986.1 and WP_014947716.1 and WP_049586573.1 and WP_049588704.1 and WP_014947977.1 and WP_014975444.1 and WP_049585990.1 and WP_049585872.1 and WP_049586883.1 and WP_012519228.1 and WP_039228916.1 and WP_014948671.1 and WP_012518092.1 and WP_014950908.1 and WP_014950912.1 and WP_012519224.1 and WP_014950907.1 and WP_014997064.1 and WP_012519216.1 and WP_014950911.1 and WP_049585808.1 and WP_014948552.1 and WP_014947978.1 and WP_012519954.1 and WP_014948727.1 and WP_049588779.1 and WP_012519217.1 and WP_049589208.1 and WP_012518206.1 and WP_012516959.1 and WP_012518091.1 and WP_015068303.1 and WP_049586879.1 and WP_014951043.1 and WP_012517169.1 and WP_014951037.1 and WP_014947975.1",
 "annotation":{
 "metanetx.reaction":"MNXR134852",
 "sbo":"SBO:0000176",
@@ -31998,7 +31998,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08435 and TK37_RS11220 and TK37_RS11660 and TK37_RS03755 and TK37_RS18545",
+"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
 "annotation":{
 "ec-code":"6.2.1.3",
 "metanetx.reaction":"MNXR134819",
@@ -32015,7 +32015,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10055 and TK37_RS02590",
+"gene_reaction_rule":"WP_049587399.1 and WP_014978530.1",
 "annotation":{
 "bigg.reaction":[
 "GAL10",
@@ -32048,7 +32048,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18435",
+"gene_reaction_rule":"WP_014950149.1",
 "annotation":{
 "bigg.reaction":[
 "MTHFCm",
@@ -32081,7 +32081,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17055",
+"gene_reaction_rule":"WP_049588753.1",
 "annotation":{
 "ec-code":"2.3.2.4",
 "kegg.orthology":[
@@ -32108,7 +32108,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17870",
+"gene_reaction_rule":"WP_014949007.1",
 "annotation":{
 "bigg.reaction":[
 "AGP1_2",
@@ -32137,7 +32137,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS18640 and TK37_RS13800) or TK37_RS16140",
+"gene_reaction_rule":"(WP_014949721.1 and WP_049588230.1) or WP_049588647.1",
 "annotation":{
 "bigg.reaction":[
 "TYRTAi",
@@ -32193,7 +32193,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03640",
+"gene_reaction_rule":"WP_049586127.1",
 "annotation":{
 "bigg.reaction":[
 "AP4AH",
@@ -32224,7 +32224,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07910",
+"gene_reaction_rule":"WP_049586958.1",
 "annotation":{
 "bigg.reaction":[
 "EAR40x",
@@ -32254,7 +32254,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS20170",
+"gene_reaction_rule":"WP_039222269.1",
 "annotation":{
 "bigg.reaction":[
 "BTNL1",
@@ -32294,7 +32294,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1E140pp",
 "ec-code":"3.1.1.5",
@@ -32315,7 +32315,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13005",
+"gene_reaction_rule":"WP_080986433.1",
 "annotation":{
 "bigg.reaction":"ACNPLYSr",
 "ec-code":[
@@ -32340,7 +32340,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10785",
+"gene_reaction_rule":"WP_049587578.1",
 "annotation":{
 "bigg.reaction":[
 "TRP3_3",
@@ -32375,7 +32375,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04445",
+"gene_reaction_rule":"WP_049586274.1",
 "annotation":{
 "bigg.reaction":"FACOAE141",
 "metanetx.reaction":"MNXR135801",
@@ -32394,7 +32394,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14330 or TK37_RS14330",
+"gene_reaction_rule":"WP_049588328.1 or WP_049588328.1",
 "annotation":{
 "bigg.reaction":[
 "ACGKm",
@@ -32425,7 +32425,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14210",
+"gene_reaction_rule":"WP_014948076.1",
 "annotation":{
 "ec-code":"4.1.1.65",
 "metanetx.reaction":"MNXR136232",
@@ -32445,7 +32445,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS10875 and TK37_RS08230 and TK37_RS09355 and TK37_RS20075 and TK37_RS17090 and TK37_RS04250 and TK37_RS08845 and TK37_RS18115 and TK37_RS09010) or TK37_RS18115",
+"gene_reaction_rule":"(WP_014947786.1 and WP_049587019.1 and WP_049587262.1 and WP_049589161.1 and WP_014949232.1 and WP_039227752.1 and WP_049587138.1 and WP_014976690.1 and WP_049587170.1) or WP_014976690.1",
 "annotation":{
 "bigg.reaction":"ACOAD4f",
 "ec-code":[
@@ -32479,7 +32479,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08840",
+"gene_reaction_rule":"WP_039236747.1",
 "annotation":{
 "bigg.reaction":[
 "DGK1",
@@ -32515,7 +32515,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03325",
+"gene_reaction_rule":"WP_049586052.1",
 "annotation":{
 "bigg.reaction":"UAAGDS",
 "biocyc":"META:UDP-NACMURALGLDAPLIG-RXN",
@@ -32548,7 +32548,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07005",
+"gene_reaction_rule":"WP_049586784.1",
 "annotation":{
 "bigg.reaction":[
 "PTA",
@@ -32580,7 +32580,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04095 and TK37_RS14380",
+"gene_reaction_rule":"WP_049586202.1 and WP_049588338.1",
 "annotation":{
 "bigg.reaction":[
 "NTD5pp",
@@ -32622,7 +32622,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560",
+"gene_reaction_rule":"WP_014949559.1",
 "annotation":{
 "bigg.reaction":"3HAD161",
 "ec-code":"4.2.1.61",
@@ -32642,7 +32642,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13275 and TK37_RS04100",
+"gene_reaction_rule":"WP_053103824.1 and WP_014948398.1",
 "annotation":{
 "bigg.reaction":"PPKr",
 "ec-code":"2.7.4.1",
@@ -32663,7 +32663,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06155",
+"gene_reaction_rule":"WP_049586630.1",
 "annotation":{
 "bigg.reaction":"PSSA120",
 "ec-code":"2.7.8.8",
@@ -32684,7 +32684,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18245",
+"gene_reaction_rule":"WP_049588898.1",
 "annotation":{
 "ec-code":"1.1.1.133",
 "metanetx.reaction":"MNXR134473",
@@ -32703,7 +32703,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14210",
+"gene_reaction_rule":"WP_014948076.1",
 "annotation":{
 "bigg.reaction":"PSD161",
 "ec-code":"4.1.1.65",
@@ -32723,7 +32723,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02510",
+"gene_reaction_rule":"WP_049585955.1",
 "annotation":{
 "bigg.reaction":"NMNDA",
 "biocyc":"META:NMNAMIDOHYDRO-RXN",
@@ -32753,7 +32753,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17735",
+"gene_reaction_rule":"WP_049588839.1",
 "annotation":{
 "bigg.reaction":[
 "XANt6",
@@ -32783,7 +32783,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00095",
+"gene_reaction_rule":"WP_049585438.1",
 "annotation":{
 "bigg.reaction":"SSALx",
 "biocyc":[
@@ -32822,7 +32822,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15755",
+"gene_reaction_rule":"WP_049588590.1",
 "annotation":{
 "bigg.reaction":"HMSH",
 "ec-code":"3.7.1.9",
@@ -32847,7 +32847,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05800 or TK37_RS05800",
+"gene_reaction_rule":"WP_049586577.1 or WP_049586577.1",
 "annotation":{
 "bigg.reaction":"DMPPS",
 "biocyc":"META:RXN0-884",
@@ -32878,7 +32878,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06025",
+"gene_reaction_rule":"WP_049586604.1",
 "annotation":{
 "bigg.reaction":[
 "PGPP180pp",
@@ -32904,7 +32904,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13910",
+"gene_reaction_rule":"WP_014980177.1",
 "annotation":{
 "bigg.reaction":[
 "GLNS",
@@ -32933,7 +32933,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05605",
+"gene_reaction_rule":"WP_080986392.1",
 "annotation":{
 "bigg.reaction":[
 "YLR231C_1",
@@ -32965,7 +32965,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2G180",
 "ec-code":"3.1.1.5",
@@ -32986,7 +32986,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04230 and TK37_RS06135 and TK37_RS17650",
+"gene_reaction_rule":"WP_049586233.1 and WP_049586624.1 and WP_049588824.1",
 "annotation":{
 "bigg.reaction":[
 "LDH_D",
@@ -33021,7 +33021,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17600 and TK37_RS14480",
+"gene_reaction_rule":"WP_014950684.1 and WP_049588355.1",
 "annotation":{
 "bigg.reaction":[
 "GLXO1",
@@ -33044,7 +33044,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03540",
+"gene_reaction_rule":"WP_039218556.1",
 "annotation":{
 "bigg.reaction":"RBKr",
 "biocyc":"META:RIBOKIN-RXN",
@@ -33075,7 +33075,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06025",
+"gene_reaction_rule":"WP_049586604.1",
 "annotation":{
 "bigg.reaction":[
 "PGPP141",
@@ -33099,7 +33099,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1G141pp",
 "ec-code":"3.1.1.5",
@@ -33119,7 +33119,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07765",
+"gene_reaction_rule":"WP_014950772.1",
 "annotation":{
 "bigg.reaction":[
 "ALLNt2",
@@ -33142,7 +33142,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS14370 and TK37_RS07625 and TK37_RS08115 and TK37_RS07380) or TK37_RS07380 or (TK37_RS14370 and TK37_RS08115 and TK37_RS07625) or TK37_RS18615",
+"gene_reaction_rule":"(WP_049588336.1 and WP_039225577.1 and WP_152910875.1 and WP_049586869.1) or WP_049586869.1 or (WP_049588336.1 and WP_152910875.1 and WP_039225577.1) or WP_014977393.1",
 "annotation":{
 "bigg.reaction":[
 "CAT",
@@ -33181,7 +33181,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08325 and TK37_RS18960",
+"gene_reaction_rule":"WP_049587047.1 and WP_049588998.1",
 "annotation":{
 "bigg.reaction":"HPPKm",
 "biocyc":"META:H2PTERIDINEPYROPHOSPHOKIN-RXN",
@@ -33218,7 +33218,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16995",
+"gene_reaction_rule":"WP_014976326.1",
 "annotation":{
 "bigg.reaction":[
 "3OAR100",
@@ -33253,7 +33253,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16120 and TK37_RS13060 and TK37_RS16130",
+"gene_reaction_rule":"WP_049588643.1 and WP_049588071.1 and WP_049588645.1",
 "annotation":{
 "bigg.reaction":"IG3PS",
 "biocyc":"META:GLUTAMIDOTRANS-RXN",
@@ -33289,7 +33289,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06025",
+"gene_reaction_rule":"WP_049586604.1",
 "annotation":{
 "ec-code":"3.1.3.27",
 "metanetx.reaction":"MNXR136261",
@@ -33309,7 +33309,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02780",
+"gene_reaction_rule":"WP_014948557.1",
 "annotation":{
 "bigg.reaction":"DASYN161",
 "ec-code":"2.7.7.41",
@@ -33330,7 +33330,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05485",
+"gene_reaction_rule":"WP_014949139.1",
 "annotation":{
 "bigg.reaction":[
 "GUAPRT",
@@ -33370,7 +33370,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17600 and TK37_RS14480",
+"gene_reaction_rule":"WP_014950684.1 and WP_049588355.1",
 "annotation":{
 "bigg.reaction":"ALDD20x",
 "biocyc":"META:RXN-10089",
@@ -33402,7 +33402,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07955",
+"gene_reaction_rule":"WP_014950808.1",
 "annotation":{
 "ec-code":"2.7.1.48",
 "kegg.reaction":"R02096",
@@ -33426,7 +33426,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02780",
+"gene_reaction_rule":"WP_014948557.1",
 "annotation":{
 "ec-code":"2.7.7.41",
 "metanetx.reaction":"MNXR136220",
@@ -33446,7 +33446,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16995",
+"gene_reaction_rule":"WP_014976326.1",
 "annotation":{
 "bigg.reaction":[
 "3OAR60",
@@ -33480,7 +33480,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11010",
+"gene_reaction_rule":"WP_014998717.1",
 "annotation":{
 "bigg.reaction":[
 "PGDHY",
@@ -33511,7 +33511,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03525",
+"gene_reaction_rule":"WP_080986378.1",
 "annotation":{
 "bigg.reaction":[
 "FTHFCL",
@@ -33541,7 +33541,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07240 and TK37_RS07245",
+"gene_reaction_rule":"WP_049586836.1 and WP_049586837.1",
 "annotation":{
 "bigg.reaction":"TRPS2",
 "biocyc":"META:RXN0-2382",
@@ -33578,7 +33578,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16245",
+"gene_reaction_rule":"WP_014949658.1",
 "annotation":{
 "bigg.reaction":[
 "PRASCS",
@@ -33615,7 +33615,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03445 or (TK37_RS01080 and TK37_RS13150)",
+"gene_reaction_rule":"WP_049586083.1 or (WP_049585701.1 and WP_049588105.1)",
 "annotation":{
 "bigg.reaction":[
 "AGM3PApp",
@@ -33638,7 +33638,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02775",
+"gene_reaction_rule":"WP_080986374.1",
 "annotation":{
 "biocyc":"META:RXN0-5180",
 "ec-code":"2.5.1.-",
@@ -33661,7 +33661,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19125 and TK37_RS15185",
+"gene_reaction_rule":"WP_049589015.1 and WP_049588496.1",
 "annotation":{
 "bigg.reaction":"DDGLK",
 "biocyc":"META:DEOXYGLUCONOKIN-RXN",
@@ -33694,7 +33694,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14835",
+"gene_reaction_rule":"WP_049588435.1",
 "annotation":{
 "bigg.reaction":"G3PD6",
 "ec-code":"1.1.99.5",
@@ -33716,7 +33716,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10875 and TK37_RS08230 and TK37_RS09355 and TK37_RS20075 and TK37_RS17090 and TK37_RS04250 and TK37_RS08845 and TK37_RS18115 and TK37_RS09010",
+"gene_reaction_rule":"WP_014947786.1 and WP_049587019.1 and WP_049587262.1 and WP_049589161.1 and WP_014949232.1 and WP_039227752.1 and WP_049587138.1 and WP_014976690.1 and WP_049587170.1",
 "annotation":{
 "bigg.reaction":[
 "GLUTCOADHc",
@@ -33744,7 +33744,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09125",
+"gene_reaction_rule":"WP_049587197.1",
 "annotation":{
 "bigg.reaction":"O16AP1pp",
 "metanetx.reaction":"MNXR135905",
@@ -33764,7 +33764,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04315",
+"gene_reaction_rule":"WP_049586246.1",
 "annotation":{
 "ec-code":"2.7.1.11",
 "kegg.orthology":[
@@ -33786,7 +33786,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17360",
+"gene_reaction_rule":"WP_049588788.1",
 "annotation":{
 "bigg.reaction":[
 "RPE1",
@@ -33812,7 +33812,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02475 and TK37_RS02470",
+"gene_reaction_rule":"WP_049585948.1 and WP_049585947.1",
 "annotation":{
 "bigg.reaction":"IPPMIa",
 "biocyc":"META:RXN-8991",
@@ -33845,7 +33845,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02480",
+"gene_reaction_rule":"WP_049585949.1",
 "annotation":{
 "bigg.reaction":[
 "IPMDr",
@@ -33879,7 +33879,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14230",
+"gene_reaction_rule":"WP_049588315.1",
 "annotation":{
 "bigg.reaction":[
 "NDP3g",
@@ -33923,7 +33923,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10360 and TK37_RS13625",
+"gene_reaction_rule":"WP_015066029.1 and WP_014976618.1",
 "annotation":{
 "ec-code":"2.7.1.107",
 "metanetx.reaction":"MNXR136254",
@@ -33943,7 +33943,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2G141",
 "ec-code":"3.1.1.5",
@@ -33964,7 +33964,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07910",
+"gene_reaction_rule":"WP_049586958.1",
 "annotation":{
 "bigg.reaction":"ACOAD1",
 "biocyc":"META:RXN-12558",
@@ -33995,7 +33995,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07005",
+"gene_reaction_rule":"WP_049586784.1",
 "annotation":{
 "bigg.reaction":[
 "PTAr_ppa",
@@ -34037,7 +34037,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16145",
+"gene_reaction_rule":"WP_049588648.1",
 "annotation":{
 "biocyc":"META:HISTALDEHYD-RXN",
 "ec-code":"1.1.1.23",
@@ -34066,7 +34066,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13780",
+"gene_reaction_rule":"WP_049588224.1",
 "annotation":{
 "bigg.reaction":"PGSA180",
 "ec-code":"2.7.8.5",
@@ -34087,7 +34087,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08970",
+"gene_reaction_rule":"WP_014950265.1",
 "annotation":{
 "bigg.reaction":[
 "UPPRT",
@@ -34118,7 +34118,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10360 and TK37_RS13625",
+"gene_reaction_rule":"WP_015066029.1 and WP_014976618.1",
 "annotation":{
 "bigg.reaction":"DAGK180",
 "ec-code":"2.7.1.107",
@@ -34140,7 +34140,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03435",
+"gene_reaction_rule":"WP_049586081.1",
 "annotation":{
 "bigg.reaction":[
 "QPT1_1",
@@ -34172,7 +34172,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17000 and TK37_RS16990",
+"gene_reaction_rule":"WP_012518211.1 and WP_049588745.1",
 "annotation":{
 "bigg.reaction":[
 "MCT1",
@@ -34207,7 +34207,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02750 or (TK37_RS13980 and TK37_RS20685) or (TK37_RS04495 and TK37_RS07675) or TK37_RS05630 or TK37_RS18985 or TK37_RS05630",
+"gene_reaction_rule":"WP_049585982.1 or (WP_014999437.1 and WP_053103828.1) or (WP_049586284.1 and WP_080986400.1) or WP_049586533.1 or WP_049589000.1 or WP_049586533.1",
 "annotation":{
 "ec-code":"3.4.11.2",
 "metanetx.reaction":"MNXR100349",
@@ -34227,7 +34227,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2A160",
 "ec-code":"3.1.1.5",
@@ -34250,7 +34250,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS02555 and TK37_RS02545 and TK37_RS02540) or TK37_RS02550",
+"gene_reaction_rule":"(WP_014975830.1 and WP_049585959.1 and WP_049585958.1) or WP_049585960.1",
 "annotation":{
 "bigg.reaction":"HEMEti",
 "metanetx.reaction":"MNXR142131",
@@ -34269,7 +34269,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17870",
+"gene_reaction_rule":"WP_014949007.1",
 "annotation":{
 "bigg.reaction":[
 "ALA_Dt6",
@@ -34297,7 +34297,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06740",
+"gene_reaction_rule":"WP_049586742.1",
 "annotation":{
 "bigg.reaction":"FLVR",
 "biocyc":[
@@ -34332,7 +34332,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16985 or TK37_RS11900 or TK37_RS17005",
+"gene_reaction_rule":"WP_014949212.1 or WP_014949953.1 or WP_049588746.1",
 "annotation":{
 "bigg.reaction":[
 "CEM1_1",
@@ -34370,7 +34370,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19095 and TK37_RS17645 and TK37_RS15160",
+"gene_reaction_rule":"WP_039227034.1 and WP_015068029.1 and WP_049588512.1",
 "annotation":{
 "bigg.reaction":[
 "CYB2",
@@ -34398,7 +34398,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11035",
+"gene_reaction_rule":"WP_049587596.1",
 "annotation":{
 "bigg.reaction":[
 "MPL",
@@ -34457,7 +34457,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13910",
+"gene_reaction_rule":"WP_014980177.1",
 "annotation":{
 "bigg.reaction":"GLNSP2",
 "ec-code":"6.3.5.-",
@@ -34482,7 +34482,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14890",
+"gene_reaction_rule":"WP_014951390.1",
 "annotation":{
 "bigg.reaction":"G3PAT140",
 "ec-code":"2.3.1.15",
@@ -34502,7 +34502,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07120",
+"gene_reaction_rule":"WP_049586806.1",
 "annotation":{
 "bigg.reaction":[
 "HSERTA",
@@ -34538,7 +34538,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02500",
+"gene_reaction_rule":"WP_049585953.1",
 "annotation":{
 "biocyc":"META:6.3.4.16-RXN",
 "ec-code":[
@@ -34564,7 +34564,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01640 and TK37_RS00075",
+"gene_reaction_rule":"WP_049585840.1 and WP_014951323.1",
 "annotation":{
 "bigg.reaction":[
 "BPNT",
@@ -34600,7 +34600,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03865",
+"gene_reaction_rule":"WP_014948339.1",
 "annotation":{
 "bigg.reaction":"DHAPT",
 "biocyc":"META:2.7.1.121-RXN",
@@ -34632,7 +34632,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03705",
+"gene_reaction_rule":"WP_049586135.1",
 "annotation":{
 "biocyc":"META:HOLO-ACP-SYNTH-RXN",
 "ec-code":[
@@ -34665,7 +34665,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13235",
+"gene_reaction_rule":"WP_049588118.1",
 "annotation":{
 "bigg.reaction":[
 "GALt2pp",
@@ -34689,7 +34689,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14255",
+"gene_reaction_rule":"WP_049588317.1",
 "annotation":{
 "bigg.reaction":[
 "GPD2",
@@ -34728,7 +34728,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04425 and TK37_RS04420",
+"gene_reaction_rule":"WP_049586269.1 and WP_049586267.1",
 "annotation":{
 "ec-code":"1.2.4.4",
 "kegg.orthology":[
@@ -34756,7 +34756,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12790",
+"gene_reaction_rule":"WP_049588021.1",
 "annotation":{
 "bigg.reaction":[
 "YNK1_4",
@@ -34792,7 +34792,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03355",
+"gene_reaction_rule":"WP_049586058.1",
 "annotation":{
 "bigg.reaction":"UAMAS",
 "biocyc":"META:UDP-NACMUR-ALA-LIG-RXN",
@@ -34824,7 +34824,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08230 or (TK37_RS10875 and TK37_RS08230 and TK37_RS09355 and TK37_RS20075 and TK37_RS17090 and TK37_RS04250 and TK37_RS08845 and TK37_RS18115 and TK37_RS09010)",
+"gene_reaction_rule":"WP_049587019.1 or (WP_014947786.1 and WP_049587019.1 and WP_049587262.1 and WP_049589161.1 and WP_014949232.1 and WP_039227752.1 and WP_049587138.1 and WP_014976690.1 and WP_049587170.1)",
 "annotation":{
 "bigg.reaction":"ACOAD1f",
 "ec-code":[
@@ -34862,7 +34862,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00240",
+"gene_reaction_rule":"WP_049585742.1",
 "annotation":{
 "bigg.reaction":[
 "IMPC",
@@ -34897,7 +34897,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01640 and TK37_RS00075",
+"gene_reaction_rule":"WP_049585840.1 and WP_014951323.1",
 "annotation":{
 "biocyc":"META:R163-RXN",
 "ec-code":"3.1.3.7",
@@ -34922,7 +34922,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15640 or TK37_RS15640",
+"gene_reaction_rule":"WP_014947970.1 or WP_014947970.1",
 "annotation":{
 "bigg.reaction":[
 "PGM",
@@ -34967,7 +34967,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02750 or (TK37_RS13980 and TK37_RS20685) or (TK37_RS04495 and TK37_RS07675) or TK37_RS05630 or TK37_RS18985 or TK37_RS05630",
+"gene_reaction_rule":"WP_049585982.1 or (WP_014999437.1 and WP_053103828.1) or (WP_049586284.1 and WP_080986400.1) or WP_049586533.1 or WP_049589000.1 or WP_049586533.1",
 "annotation":{
 "bigg.reaction":"MEAMP1(ala-glu)",
 "metanetx.reaction":"MNXR137143",
@@ -34986,7 +34986,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19680",
+"gene_reaction_rule":"WP_049589075.1",
 "annotation":{
 "bigg.reaction":[
 "YBR184W_5",
@@ -35019,7 +35019,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03165",
+"gene_reaction_rule":"WP_049586037.1",
 "annotation":{
 "bigg.reaction":[
 "P5CR",
@@ -35054,7 +35054,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06295 and TK37_RS06300",
+"gene_reaction_rule":"WP_014949268.1 and WP_014976359.1",
 "annotation":{
 "biocyc":"META:NADH-PEROXIDASE-RXN",
 "ec-code":"1.11.1.1",
@@ -35075,7 +35075,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04680",
+"gene_reaction_rule":"WP_049586331.1",
 "annotation":{
 "bigg.reaction":"DHSKDH",
 "biocyc":"META:DHSHIKIMATE-DEHYDRO-RXN",
@@ -35108,7 +35108,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05800",
+"gene_reaction_rule":"WP_049586577.1",
 "annotation":{
 "bigg.reaction":"IPDPS",
 "biocyc":"META:ISPH2-RXN",
@@ -35133,7 +35133,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08435 and TK37_RS11220 and TK37_RS11660 and TK37_RS03755 and TK37_RS18545",
+"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
 "annotation":{
 "bigg.reaction":[
 "FACOAL161p",
@@ -35156,7 +35156,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03035",
+"gene_reaction_rule":"WP_049586019.1",
 "annotation":{
 "biocyc":"META:RXN-2962",
 "ec-code":"1.1.1.284",
@@ -35178,7 +35178,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07765",
+"gene_reaction_rule":"WP_014950772.1",
 "annotation":{
 "bigg.reaction":[
 "FCY2_1",
@@ -35206,7 +35206,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14415",
+"gene_reaction_rule":"WP_014948098.1",
 "annotation":{
 "bigg.reaction":"AIRC3",
 "biocyc":"META:RXN0-743",
@@ -35238,7 +35238,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02500",
+"gene_reaction_rule":"WP_049585953.1",
 "annotation":{
 "bigg.reaction":[
 "CTPS2",
@@ -35272,7 +35272,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11440",
+"gene_reaction_rule":"WP_049587678.1",
 "annotation":{
 "bigg.reaction":"ILEDH2",
 "biocyc":"META:ILEDEAMINE-RXN",
@@ -35296,7 +35296,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS13980 and TK37_RS20685) or TK37_RS18985 or TK37_RS05235 or TK37_RS04495",
+"gene_reaction_rule":"(WP_014999437.1 and WP_053103828.1) or WP_049589000.1 or WP_014980757.1 or WP_049586284.1",
 "annotation":{
 "bigg.reaction":[
 "TRIA",
@@ -35341,7 +35341,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS12610 and TK37_RS15400 and TK37_RS03220 and TK37_RS19185 and TK37_RS01765) or TK37_RS06695",
+"gene_reaction_rule":"(WP_049587995.1 and WP_049588550.1 and WP_049586043.1 and WP_014949867.1 and WP_049585855.1) or WP_049586739.1",
 "annotation":{
 "bigg.reaction":[
 "AKP1",
@@ -35369,7 +35369,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06570",
+"gene_reaction_rule":"WP_049586730.1",
 "annotation":{
 "bigg.reaction":[
 "MAN1PT2r",
@@ -35400,7 +35400,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10460",
+"gene_reaction_rule":"WP_015066019.1",
 "annotation":{
 "bigg.reaction":"ACYP",
 "ec-code":"3.6.1.7",
@@ -35426,7 +35426,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03980",
+"gene_reaction_rule":"WP_014975732.1",
 "annotation":{
 "bigg.reaction":[
 "DHPRx",
@@ -35455,7 +35455,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12790",
+"gene_reaction_rule":"WP_049588021.1",
 "annotation":{
 "bigg.reaction":[
 "NDPK9",
@@ -35486,7 +35486,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2G140",
 "ec-code":"3.1.1.5",
@@ -35508,7 +35508,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18125",
+"gene_reaction_rule":"WP_014979424.1",
 "annotation":{
 "ec-code":"2.1.2.2",
 "kegg.orthology":[
@@ -35534,7 +35534,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14880",
+"gene_reaction_rule":"WP_014977810.1",
 "annotation":{
 "bigg.reaction":[
 "ILV3_3",
@@ -35568,7 +35568,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12790",
+"gene_reaction_rule":"WP_049588021.1",
 "annotation":{
 "bigg.reaction":[
 "NDPK5",
@@ -35601,7 +35601,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14210",
+"gene_reaction_rule":"WP_014948076.1",
 "annotation":{
 "ec-code":"4.1.1.65",
 "metanetx.reaction":"MNXR136231",
@@ -35620,7 +35620,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02750 or (TK37_RS13980 and TK37_RS20685) or (TK37_RS04495 and TK37_RS07675) or TK37_RS05630 or TK37_RS18985 or TK37_RS05630",
+"gene_reaction_rule":"WP_049585982.1 or (WP_014999437.1 and WP_053103828.1) or (WP_049586284.1 and WP_080986400.1) or WP_049586533.1 or WP_049589000.1 or WP_049586533.1",
 "annotation":{
 "bigg.reaction":"MEAMP1(ala-asp)",
 "biocyc":"META:RXN0-6975",
@@ -35642,7 +35642,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12720",
+"gene_reaction_rule":"WP_014950183.1",
 "annotation":{
 "bigg.reaction":"MI4PP",
 "biocyc":[
@@ -35677,7 +35677,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16705 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715",
+"gene_reaction_rule":"WP_049588707.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1",
 "annotation":{
 "bigg.reaction":[
 "HACD4i",
@@ -35717,7 +35717,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06970 or TK37_RS06970",
+"gene_reaction_rule":"WP_049586778.1 or WP_049586778.1",
 "annotation":{
 "ec-code":"1.14.13.-",
 "kegg.reaction":"R06146",
@@ -35738,7 +35738,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14835",
+"gene_reaction_rule":"WP_049588435.1",
 "annotation":{
 "bigg.reaction":[
 "G3PDm",
@@ -35774,7 +35774,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19260",
+"gene_reaction_rule":"WP_049589033.1",
 "annotation":{
 "bigg.reaction":"FGLU",
 "biocyc":"META:FORMIMINOGLUTAMASE-RXN",
@@ -35802,7 +35802,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05980",
+"gene_reaction_rule":"WP_014979776.1",
 "annotation":{
 "bigg.reaction":"U23GAAT",
 "biocyc":"META:UDPHYDROXYMYRGLUCOSAMNACETYLTRANS-RXN",
@@ -35833,7 +35833,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08575",
+"gene_reaction_rule":"WP_039226879.1",
 "annotation":{
 "bigg.reaction":"DAPDC",
 "biocyc":"META:DIAMINOPIMDECARB-RXN",
@@ -35862,7 +35862,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18685 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715 and TK37_RS11765 and TK37_RS01845",
+"gene_reaction_rule":"WP_049588954.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1 and WP_014976911.1 and WP_014948837.1",
 "annotation":{
 "bigg.reaction":[
 "ECOAH2c",
@@ -35895,7 +35895,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02480",
+"gene_reaction_rule":"WP_049585949.1",
 "annotation":{
 "ec-code":"1.1.1.85",
 "kegg.orthology":"K00052",
@@ -35918,7 +35918,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07025 and TK37_RS09605",
+"gene_reaction_rule":"WP_014948985.1 and WP_049587314.1",
 "annotation":{
 "bigg.reaction":"ADPRDP",
 "biocyc":[
@@ -35961,7 +35961,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05595 or (TK37_RS15255 and TK37_RS01710 and TK37_RS17085)",
+"gene_reaction_rule":"WP_049586525.1 or (WP_024015658.1 and WP_049585851.1 and WP_049588755.1)",
 "annotation":{
 "bigg.reaction":[
 "KAT4",
@@ -35997,7 +35997,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11440",
+"gene_reaction_rule":"WP_049587678.1",
 "annotation":{
 "bigg.reaction":[
 "LLEUDr",
@@ -36025,7 +36025,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01185",
+"gene_reaction_rule":"WP_049585734.1",
 "annotation":{
 "bigg.reaction":[
 "HEX7",
@@ -36059,7 +36059,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16705 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715",
+"gene_reaction_rule":"WP_049588707.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1",
 "annotation":{
 "biocyc":"META:RXN0-2044",
 "ec-code":[
@@ -36094,7 +36094,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09315",
+"gene_reaction_rule":"WP_049587249.1",
 "annotation":{
 "bigg.reaction":[
 "MOBDabcpp",
@@ -36123,7 +36123,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17000",
+"gene_reaction_rule":"WP_012518211.1",
 "annotation":{
 "bigg.reaction":"AACPS7",
 "biocyc":"META:RXN-13264",
@@ -36145,7 +36145,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07910",
+"gene_reaction_rule":"WP_049586958.1",
 "annotation":{
 "bigg.reaction":[
 "OCMAT3",
@@ -36177,7 +36177,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11050",
+"gene_reaction_rule":"WP_014998709.1",
 "annotation":{
 "biocyc":[
 "META:RXN-3341",
@@ -36209,7 +36209,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17750",
+"gene_reaction_rule":"WP_049588841.1",
 "annotation":{
 "biocyc":"META:URUR-RXN",
 "ec-code":[
@@ -36242,7 +36242,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04445",
+"gene_reaction_rule":"WP_049586274.1",
 "annotation":{
 "bigg.reaction":[
 "PTE7x",
@@ -36267,7 +36267,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1E120pp",
 "ec-code":"3.1.1.5",
@@ -36289,7 +36289,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15170",
+"gene_reaction_rule":"WP_049588490.1",
 "annotation":{
 "bigg.reaction":[
 "LCADm",
@@ -36331,7 +36331,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05565",
+"gene_reaction_rule":"WP_080986391.1",
 "annotation":{
 "biocyc":"META:4.1.3.26-RXN",
 "ec-code":[
@@ -36360,7 +36360,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02175",
+"gene_reaction_rule":"WP_049585925.1",
 "annotation":{
 "bigg.reaction":[
 "BIO3",
@@ -36393,7 +36393,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17390",
+"gene_reaction_rule":"WP_049588782.1",
 "annotation":{
 "bigg.reaction":"SGSAD",
 "biocyc":"META:SUCCGLUALDDEHYD-RXN",
@@ -36423,7 +36423,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00230",
+"gene_reaction_rule":"WP_049585482.1",
 "annotation":{
 "bigg.reaction":[
 "ADE5_7_1",
@@ -36455,7 +36455,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18685 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715 and TK37_RS11765 and TK37_RS01845",
+"gene_reaction_rule":"WP_049588954.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1 and WP_014976911.1 and WP_014948837.1",
 "annotation":{
 "bigg.reaction":[
 "ECOAH9ir",
@@ -36489,7 +36489,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13935",
+"gene_reaction_rule":"WP_049588248.1",
 "annotation":{
 "bigg.reaction":"AGPAT181",
 "ec-code":"2.3.1.51",
@@ -36509,7 +36509,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07040 and TK37_RS07045 and TK37_RS12615",
+"gene_reaction_rule":"WP_049586789.1 and WP_014948979.1 and WP_049588023.1",
 "annotation":{
 "bigg.reaction":[
 "GLUN",
@@ -36559,7 +36559,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06025",
+"gene_reaction_rule":"WP_049586604.1",
 "annotation":{
 "ec-code":"3.1.3.27",
 "metanetx.reaction":"MNXR136265",
@@ -36576,7 +36576,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07235",
+"gene_reaction_rule":"WP_049586834.1",
 "annotation":{
 "bigg.reaction":[
 "PRAI",
@@ -36613,7 +36613,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09780 and TK37_RS13445 and TK37_RS18295 and TK37_RS07135 and TK37_RS17935",
+"gene_reaction_rule":"WP_049587342.1 and WP_014977336.1 and WP_049588907.1 and WP_049586860.1 and WP_049588854.1",
 "annotation":{
 "bigg.reaction":[
 "ALCD2if",
@@ -36666,7 +36666,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560",
+"gene_reaction_rule":"WP_014949559.1",
 "annotation":{
 "ec-code":"4.2.1.0",
 "metanetx.reaction":"MNXR134899",
@@ -36685,7 +36685,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05955",
+"gene_reaction_rule":"WP_039231744.1",
 "annotation":{
 "bigg.reaction":[
 "PSP_Lpp",
@@ -36725,7 +36725,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07765",
+"gene_reaction_rule":"WP_014950772.1",
 "annotation":{
 "bigg.reaction":[
 "YOR071C",
@@ -36750,7 +36750,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10360 and TK37_RS13625",
+"gene_reaction_rule":"WP_015066029.1 and WP_014976618.1",
 "annotation":{
 "ec-code":"2.7.1.107",
 "metanetx.reaction":"MNXR136249",
@@ -36769,7 +36769,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14890",
+"gene_reaction_rule":"WP_014951390.1",
 "annotation":{
 "ec-code":"2.3.1.15",
 "metanetx.reaction":"MNXR136204",
@@ -36789,7 +36789,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02780",
+"gene_reaction_rule":"WP_014948557.1",
 "annotation":{
 "ec-code":"2.7.7.41",
 "metanetx.reaction":"MNXR136217",
@@ -36810,7 +36810,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14500 and TK37_RS19730 and TK37_RS17765 and TK37_RS18690",
+"gene_reaction_rule":"WP_049588360.1 and WP_049589086.1 and WP_049588843.1 and WP_014976719.1",
 "annotation":{
 "ec-code":"2.3.2.2",
 "metanetx.reaction":"MNXR105362",
@@ -36830,7 +36830,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02775",
+"gene_reaction_rule":"WP_080986374.1",
 "annotation":{
 "ec-code":[
 "2.5.1.31",
@@ -36854,7 +36854,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11425 and TK37_RS11680",
+"gene_reaction_rule":"WP_049587676.1 and WP_049587727.1",
 "annotation":{
 "bigg.reaction":[
 "FUMAC",
@@ -36889,7 +36889,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06025",
+"gene_reaction_rule":"WP_049586604.1",
 "annotation":{
 "ec-code":"3.1.3.27",
 "metanetx.reaction":"MNXR136262",
@@ -36908,7 +36908,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05595 or (TK37_RS15255 and TK37_RS01710 and TK37_RS17085)",
+"gene_reaction_rule":"WP_049586525.1 or (WP_024015658.1 and WP_049585851.1 and WP_049588755.1)",
 "annotation":{
 "bigg.reaction":[
 "ACACT7p",
@@ -36951,7 +36951,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09630 and TK37_RS08150",
+"gene_reaction_rule":"WP_049587320.1 and WP_049586999.1",
 "annotation":{
 "biocyc":"META:UROPORIIIMETHYLTRANSA-RXN",
 "ec-code":"2.1.1.107",
@@ -36973,7 +36973,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14890",
+"gene_reaction_rule":"WP_014951390.1",
 "annotation":{
 "ec-code":"2.3.1.15",
 "metanetx.reaction":"MNXR126823",
@@ -36993,7 +36993,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS20045 or TK37_RS20045",
+"gene_reaction_rule":"WP_049589151.1 or WP_049589151.1",
 "annotation":{
 "bigg.reaction":"PERD",
 "biocyc":"META:ERYTHRON4PDEHYDROG-RXN",
@@ -37020,7 +37020,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06000",
+"gene_reaction_rule":"WP_014950090.1",
 "annotation":{
 "biocyc":"META:RIBOFLAVIN-SYN-RXN",
 "ec-code":"2.5.1.9",
@@ -37048,7 +37048,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17275",
+"gene_reaction_rule":"WP_039229281.1",
 "annotation":{
 "bigg.reaction":"CBMLPTAH",
 "biocyc":"META:N-CARBAMOYLPUTRESCINE-AMIDASE-RXN",
@@ -37076,7 +37076,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16290 or TK37_RS16295",
+"gene_reaction_rule":"WP_014949649.1 or WP_014949648.1",
 "annotation":{
 "bigg.reaction":[
 "RNDR1n",
@@ -37111,7 +37111,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14210",
+"gene_reaction_rule":"WP_014948076.1",
 "annotation":{
 "bigg.reaction":"PSD160",
 "ec-code":"4.1.1.65",
@@ -37129,7 +37129,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14530",
+"gene_reaction_rule":"WP_049588368.1",
 "annotation":{
 "bigg.reaction":[
 "ALAR",
@@ -37158,7 +37158,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560 or TK37_RS02805",
+"gene_reaction_rule":"WP_014949559.1 or WP_014948562.1",
 "annotation":{
 "ec-code":"4.2.1.0",
 "metanetx.reaction":"MNXR134870",
@@ -37179,7 +37179,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07225 and TK37_RS07220",
+"gene_reaction_rule":"WP_049586830.1 and WP_049586828.1",
 "annotation":{
 "bigg.reaction":"ANS2",
 "ec-code":"4.1.3.27",
@@ -37211,7 +37211,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS11915 and TK37_RS13525 and TK37_RS10415) or TK37_RS13160 or (TK37_RS04190 and TK37_RS13155 and TK37_RS05520)",
+"gene_reaction_rule":"(WP_049587790.1 and WP_049588184.1 and WP_012516877.1) or WP_012519580.1 or (WP_014975770.1 and WP_014950543.1 and WP_049586503.1)",
 "annotation":{
 "bigg.reaction":[
 "GLUDyi",
@@ -37251,7 +37251,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01635 and TK37_RS01650",
+"gene_reaction_rule":"WP_014948795.1 and WP_049585842.1",
 "annotation":{
 "bigg.reaction":[
 "SADT1r",
@@ -37286,7 +37286,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2G181",
 "ec-code":"3.1.1.5",
@@ -37305,7 +37305,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560 or TK37_RS02805",
+"gene_reaction_rule":"WP_014949559.1 or WP_014948562.1",
 "annotation":{
 "bigg.reaction":[
 "HHYHL2",
@@ -37343,7 +37343,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16665",
+"gene_reaction_rule":"WP_014976412.1",
 "annotation":{
 "bigg.reaction":[
 "NNAT",
@@ -37384,7 +37384,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14860",
+"gene_reaction_rule":"WP_014951396.1",
 "annotation":{
 "ec-code":"5.4.99.3",
 "kegg.reaction":"R03052",
@@ -37405,7 +37405,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05585",
+"gene_reaction_rule":"WP_049586522.1",
 "annotation":{
 "bigg.reaction":"MBCOAi",
 "ec-code":[
@@ -37436,7 +37436,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10990",
+"gene_reaction_rule":"WP_014949855.1",
 "annotation":{
 "ec-code":"2.7.1.40",
 "kegg.orthology":[
@@ -37462,7 +37462,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06025",
+"gene_reaction_rule":"WP_049586604.1",
 "annotation":{
 "bigg.reaction":[
 "PGPP140pp",
@@ -37486,7 +37486,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14890",
+"gene_reaction_rule":"WP_014951390.1",
 "annotation":{
 "bigg.reaction":"G3PAT181",
 "ec-code":"2.3.1.15",
@@ -37507,7 +37507,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05995",
+"gene_reaction_rule":"WP_080986394.1",
 "annotation":{
 "bigg.reaction":[
 "DHPPDA",
@@ -37545,7 +37545,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16995",
+"gene_reaction_rule":"WP_014976326.1",
 "annotation":{
 "bigg.reaction":"HBUR1",
 "ec-code":"1.1.1.100",
@@ -37575,7 +37575,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11900 or TK37_RS17005",
+"gene_reaction_rule":"WP_014949953.1 or WP_049588746.1",
 "annotation":{
 "ec-code":[
 "2.3.1.41",
@@ -37597,7 +37597,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11820",
+"gene_reaction_rule":"WP_049587759.1",
 "annotation":{
 "bigg.reaction":[
 "ACACt2pp",
@@ -37620,7 +37620,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10925",
+"gene_reaction_rule":"WP_049587570.1",
 "annotation":{
 "bigg.reaction":[
 "THI20_2",
@@ -37655,7 +37655,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02630",
+"gene_reaction_rule":"WP_014948529.1",
 "annotation":{
 "ec-code":"2.7.8.-",
 "metanetx.reaction":"MNXR136309",
@@ -37675,7 +37675,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08045",
+"gene_reaction_rule":"WP_049586975.1",
 "annotation":{
 "ec-code":[
 "6.2.1.1",
@@ -37703,7 +37703,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19750",
+"gene_reaction_rule":"WP_049589092.1",
 "annotation":{
 "bigg.reaction":[
 "URA2_1",
@@ -37738,7 +37738,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08335",
+"gene_reaction_rule":"WP_014948274.1",
 "annotation":{
 "ec-code":"3.6.1.17",
 "kegg.orthology":[
@@ -37766,7 +37766,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1G160pp",
 "ec-code":"3.1.1.5",
@@ -37786,7 +37786,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11820",
+"gene_reaction_rule":"WP_049587759.1",
 "annotation":{
 "bigg.reaction":[
 "BUTt2r",
@@ -37808,7 +37808,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06130",
+"gene_reaction_rule":"WP_049586622.1",
 "annotation":{
 "bigg.reaction":[
 "L-LACt2r",
@@ -37837,7 +37837,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13515",
+"gene_reaction_rule":"WP_049588180.1",
 "annotation":{
 "bigg.reaction":"NODOx",
 "biocyc":"META:R621-RXN",
@@ -37863,7 +37863,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS19095 and TK37_RS17645 and TK37_RS15160) or (TK37_RS19095 and TK37_RS17645 and TK37_RS15160)",
+"gene_reaction_rule":"(WP_039227034.1 and WP_015068029.1 and WP_049588512.1) or (WP_039227034.1 and WP_015068029.1 and WP_049588512.1)",
 "annotation":{
 "bigg.reaction":[
 "L_LACD3",
@@ -37889,7 +37889,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08435 and TK37_RS11220 and TK37_RS11660 and TK37_RS03755 and TK37_RS18545",
+"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
 "annotation":{
 "bigg.reaction":[
 "FACOAL160",
@@ -37926,7 +37926,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18685 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715 and TK37_RS11765 and TK37_RS01845",
+"gene_reaction_rule":"WP_049588954.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1 and WP_014976911.1 and WP_014948837.1",
 "annotation":{
 "bigg.reaction":"ECOAH3",
 "ec-code":[
@@ -37961,7 +37961,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14890",
+"gene_reaction_rule":"WP_014951390.1",
 "annotation":{
 "ec-code":"2.3.1.15",
 "metanetx.reaction":"MNXR136207",
@@ -37983,7 +37983,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16355",
+"gene_reaction_rule":"WP_049588668.1",
 "annotation":{
 "bigg.reaction":"ALAD_L",
 "biocyc":"META:ALANINE-DEHYDROGENASE-RXN",
@@ -38010,7 +38010,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11005 or TK37_RS11005",
+"gene_reaction_rule":"WP_014979596.1 or WP_014979596.1",
 "annotation":{
 "bigg.reaction":[
 "PGL",
@@ -38047,7 +38047,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04235 and TK37_RS03260 and TK37_RS18670",
+"gene_reaction_rule":"WP_049586234.1 and WP_014950446.1 and WP_014949715.1",
 "annotation":{
 "bigg.reaction":[
 "GSHPO",
@@ -38082,7 +38082,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03380",
+"gene_reaction_rule":"WP_049586065.1",
 "annotation":{
 "bigg.reaction":"UHGADA",
 "biocyc":"META:UDPACYLGLCNACDEACETYL-RXN",
@@ -38117,7 +38117,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10790",
+"gene_reaction_rule":"WP_014975277.1",
 "annotation":{
 "bigg.reaction":"HBZOPT",
 "biocyc":"META:4OHBENZOATE-OCTAPRENYLTRANSFER-RXN",
@@ -38146,7 +38146,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02470 or TK37_RS02475",
+"gene_reaction_rule":"WP_049585947.1 or WP_049585948.1",
 "annotation":{
 "bigg.reaction":[
 "IPPMIb",
@@ -38182,7 +38182,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07955",
+"gene_reaction_rule":"WP_014950808.1",
 "annotation":{
 "ec-code":"2.7.1.48",
 "kegg.reaction":"R01880",
@@ -38205,7 +38205,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08435 and TK37_RS11220 and TK37_RS11660 and TK37_RS03755 and TK37_RS18545",
+"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
 "annotation":{
 "bigg.reaction":"ACAC",
 "biocyc":"META:ACETOACETATE--COA-LIGASE-RXN",
@@ -38232,7 +38232,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02500",
+"gene_reaction_rule":"WP_049585953.1",
 "annotation":{
 "bigg.reaction":[
 "URA7_2",
@@ -38263,7 +38263,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03075",
+"gene_reaction_rule":"WP_039226298.1",
 "annotation":{
 "bigg.reaction":[
 "TALA",
@@ -38299,7 +38299,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10360 and TK37_RS13625",
+"gene_reaction_rule":"WP_015066029.1 and WP_014976618.1",
 "annotation":{
 "ec-code":"2.7.1.107",
 "metanetx.reaction":"MNXR136253",
@@ -38318,7 +38318,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04430",
+"gene_reaction_rule":"WP_049586270.1",
 "annotation":{
 "ec-code":"2.3.1.168",
 "kegg.orthology":"K09699",
@@ -38343,7 +38343,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS20165",
+"gene_reaction_rule":"WP_049589179.1",
 "annotation":{
 "bigg.reaction":[
 "PNTK",
@@ -38382,7 +38382,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14230",
+"gene_reaction_rule":"WP_049588315.1",
 "annotation":{
 "bigg.reaction":"NDP7",
 "biocyc":[
@@ -38418,7 +38418,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03350",
+"gene_reaction_rule":"WP_049586056.1",
 "annotation":{
 "bigg.reaction":"UAGPT2",
 "ec-code":"2.4.1.227",
@@ -38442,7 +38442,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16995",
+"gene_reaction_rule":"WP_014976326.1",
 "annotation":{
 "bigg.reaction":[
 "3OAR140",
@@ -38475,7 +38475,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07500",
+"gene_reaction_rule":"WP_014976864.1",
 "annotation":{
 "bigg.reaction":"DCTPD2",
 "biocyc":"META:RXN-14118",
@@ -38503,7 +38503,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07040 and TK37_RS07045",
+"gene_reaction_rule":"WP_049586789.1 and WP_014948979.1",
 "annotation":{
 "bigg.reaction":[
 "CBPSn",
@@ -38539,7 +38539,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03445 or (TK37_RS01080 and TK37_RS13150)",
+"gene_reaction_rule":"WP_049586083.1 or (WP_049585701.1 and WP_049588105.1)",
 "annotation":{
 "bigg.reaction":"AM3PA",
 "metanetx.reaction":"MNXR95792",
@@ -38558,7 +38558,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13780",
+"gene_reaction_rule":"WP_049588224.1",
 "annotation":{
 "bigg.reaction":"PGSA141",
 "ec-code":"2.7.8.5",
@@ -38579,7 +38579,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17290",
+"gene_reaction_rule":"WP_049588787.1",
 "annotation":{
 "bigg.reaction":[
 "ME1",
@@ -38621,7 +38621,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17000",
+"gene_reaction_rule":"WP_012518211.1",
 "annotation":{
 "bigg.reaction":[
 "ACOATA",
@@ -38653,7 +38653,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03715 or TK37_RS08830",
+"gene_reaction_rule":"WP_049586138.1 or WP_039226917.1",
 "annotation":{
 "bigg.reaction":"GTPDPK",
 "biocyc":"META:GTPPYPHOSKIN-RXN",
@@ -38683,7 +38683,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04405 or TK37_RS13295",
+"gene_reaction_rule":"WP_014949528.1 or WP_049588132.1",
 "annotation":{
 "bigg.reaction":[
 "FUM1_2",
@@ -38720,7 +38720,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14220",
+"gene_reaction_rule":"WP_049588313.1",
 "annotation":{
 "bigg.reaction":[
 "GPDDA2",
@@ -38758,7 +38758,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12170",
+"gene_reaction_rule":"WP_014976528.1",
 "annotation":{
 "bigg.reaction":[
 "KDOCT2",
@@ -38790,7 +38790,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03460 or TK37_RS14160 or (TK37_RS01135 and TK37_RS14165)",
+"gene_reaction_rule":"WP_049586085.1 or WP_014975513.1 or (WP_014951084.1 and WP_049588309.1)",
 "annotation":{
 "biocyc":"META:RXN-12583",
 "ec-code":[
@@ -38825,7 +38825,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04425 and TK37_RS04420",
+"gene_reaction_rule":"WP_049586269.1 and WP_049586267.1",
 "annotation":{
 "ec-code":"1.2.4.4",
 "kegg.orthology":[
@@ -38853,7 +38853,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03060",
+"gene_reaction_rule":"WP_049586023.1",
 "annotation":{
 "bigg.reaction":[
 "THR4_1",
@@ -38889,7 +38889,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10445 and TK37_RS13690 and TK37_RS19485",
+"gene_reaction_rule":"WP_049587504.1 and WP_049588217.1 and WP_012516907.1",
 "annotation":{
 "bigg.reaction":[
 "Cut1",
@@ -38922,7 +38922,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07230",
+"gene_reaction_rule":"WP_049586832.1",
 "annotation":{
 "bigg.reaction":[
 "TRP4",
@@ -38952,7 +38952,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12245 and TK37_RS19740",
+"gene_reaction_rule":"WP_049587876.1 and WP_039225111.1",
 "annotation":{
 "bigg.reaction":[
 "CYR1",
@@ -38999,7 +38999,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07955",
+"gene_reaction_rule":"WP_014950808.1",
 "annotation":{
 "bigg.reaction":"CYTDK1",
 "biocyc":"META:CYTIKIN-RXN",
@@ -39034,7 +39034,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04230 and TK37_RS06135 and TK37_RS17650",
+"gene_reaction_rule":"WP_049586233.1 and WP_049586624.1 and WP_049588824.1",
 "annotation":{
 "bigg.reaction":"LDH_D2",
 "biocyc":"META:DLACTDEHYDROGFAD-RXN",
@@ -39059,7 +39059,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17425",
+"gene_reaction_rule":"WP_014978916.1",
 "annotation":{
 "bigg.reaction":[
 "34HPPOR",
@@ -39091,7 +39091,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07500",
+"gene_reaction_rule":"WP_014976864.1",
 "annotation":{
 "bigg.reaction":[
 "DCTPD",
@@ -39121,7 +39121,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04130",
+"gene_reaction_rule":"WP_039224609.1",
 "annotation":{
 "bigg.reaction":[
 "PIt6",
@@ -39156,7 +39156,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00615 or (TK37_RS00585 and TK37_RS05685 and TK37_RS09270) or TK37_RS09270",
+"gene_reaction_rule":"WP_014951193.1 or (WP_049585584.1 and WP_049586550.1 and WP_049587238.1) or WP_049587238.1",
 "annotation":{
 "bigg.reaction":[
 "NADH12",
@@ -39190,7 +39190,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04710",
+"gene_reaction_rule":"WP_080986386.1",
 "annotation":{
 "ec-code":"2.7.8.12",
 "metanetx.reaction":"MNXR136292",
@@ -39209,7 +39209,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16665",
+"gene_reaction_rule":"WP_014976412.1",
 "annotation":{
 "bigg.reaction":[
 "NMNATr",
@@ -39251,7 +39251,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05595 or (TK37_RS15255 and TK37_RS01710 and TK37_RS17085)",
+"gene_reaction_rule":"WP_049586525.1 or (WP_024015658.1 and WP_049585851.1 and WP_049588755.1)",
 "annotation":{
 "bigg.reaction":[
 "ACACT5r",
@@ -39284,7 +39284,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03060",
+"gene_reaction_rule":"WP_049586023.1",
 "annotation":{
 "bigg.reaction":[
 "4HTHRS",
@@ -39311,7 +39311,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03050",
+"gene_reaction_rule":"WP_049586022.1",
 "annotation":{
 "bigg.reaction":[
 "HSDy",
@@ -39347,7 +39347,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17870",
+"gene_reaction_rule":"WP_014949007.1",
 "annotation":{
 "bigg.reaction":[
 "ALAt4pp",
@@ -39371,7 +39371,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19145",
+"gene_reaction_rule":"WP_049589018.1",
 "annotation":{
 "bigg.reaction":"ALTRH",
 "biocyc":"META:ALTRODEHYDRAT-RXN",
@@ -39403,7 +39403,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07955",
+"gene_reaction_rule":"WP_014950808.1",
 "annotation":{
 "ec-code":"2.7.1.48",
 "kegg.reaction":"R00516",
@@ -39422,7 +39422,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11020 and TK37_RS19130",
+"gene_reaction_rule":"WP_014949849.1 and WP_014979614.1",
 "annotation":{
 "bigg.reaction":"DDPGA",
 "biocyc":"META:4OH2OXOGLUTARALDOL-RXN",
@@ -39453,7 +39453,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS20175 or TK37_RS20175",
+"gene_reaction_rule":"WP_049589180.1 or WP_049589180.1",
 "annotation":{
 "bigg.reaction":"UAPGR",
 "biocyc":"META:UDPNACETYLMURAMATEDEHYDROG-RXN",
@@ -39489,7 +39489,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04735",
+"gene_reaction_rule":"WP_049586350.1",
 "annotation":{
 "bigg.reaction":"CPPPGO",
 "biocyc":"META:RXN0-1461",
@@ -39518,7 +39518,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04630 and TK37_RS10370 and TK37_RS00860 and TK37_RS04635",
+"gene_reaction_rule":"WP_045980005.1 and WP_012516887.1 and WP_039229202.1 and WP_045980004.1",
 "annotation":{
 "metanetx.reaction":"MNXR105279",
 "sbo":"SBO:0000655",
@@ -39535,7 +39535,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560",
+"gene_reaction_rule":"WP_014949559.1",
 "annotation":{
 "ec-code":"4.2.1.0",
 "metanetx.reaction":"MNXR134891",
@@ -39555,7 +39555,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10460",
+"gene_reaction_rule":"WP_015066019.1",
 "annotation":{
 "bigg.reaction":"ACYP_2",
 "ec-code":"3.6.1.7",
@@ -39578,7 +39578,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04710",
+"gene_reaction_rule":"WP_080986386.1",
 "annotation":{
 "ec-code":"2.7.8.12",
 "metanetx.reaction":"MNXR136289",
@@ -39598,7 +39598,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS20165",
+"gene_reaction_rule":"WP_049589179.1",
 "annotation":{
 "ec-code":"2.7.1.33",
 "kegg.orthology":[
@@ -39627,7 +39627,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05570 or TK37_RS05580",
+"gene_reaction_rule":"WP_049586517.1 or WP_049586521.1",
 "annotation":{
 "bigg.reaction":[
 "MCCC",
@@ -39658,7 +39658,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06570",
+"gene_reaction_rule":"WP_049586730.1",
 "annotation":{
 "bigg.reaction":[
 "PMI40",
@@ -39689,7 +39689,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2G160",
 "ec-code":"3.1.1.5",
@@ -39711,7 +39711,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16305 and TK37_RS02825 and TK37_RS07200 and TK37_RS04855 and TK37_RS07205 and TK37_RS04860 and TK37_RS04845 and TK37_RS19695 and TK37_RS07990 and TK37_RS16040 and TK37_RS12130 and TK37_RS18555 and TK37_RS17025 and TK37_RS05695 and TK37_RS13975 and TK37_RS19905 and TK37_RS19375 and TK37_RS08290 and TK37_RS00305 and TK37_RS16670",
+"gene_reaction_rule":"WP_014949646.1 and WP_075176114.1 and WP_014948948.1 and WP_049586368.1 and WP_049586823.1 and WP_049586370.1 and WP_049586366.1 and WP_049589078.1 and WP_049586968.1 and WP_049588632.1 and WP_049587846.1 and WP_080986472.1 and WP_049588749.1 and WP_014976297.1 and WP_012519633.1 and WP_049589114.1 and WP_049589054.1 and WP_049587032.1 and WP_049585499.1 and WP_049588702.1",
 "annotation":{
 "metanetx.reaction":"MNXR142134",
 "sbo":"SBO:0000176",
@@ -39730,7 +39730,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15510 and TK37_RS15520",
+"gene_reaction_rule":"WP_049588561.1 and WP_049588563.1",
 "annotation":{
 "bigg.reaction":"FTHFD",
 "biocyc":"META:FORMYLTHFDEFORMYL-RXN",
@@ -39758,7 +39758,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2E141",
 "ec-code":"3.1.1.5",
@@ -39778,7 +39778,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18875 and TK37_RS16105",
+"gene_reaction_rule":"WP_014949030.1 and WP_049588640.1",
 "annotation":{
 "bigg.reaction":[
 "FORt2",
@@ -39800,7 +39800,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04365 and TK37_RS04360",
+"gene_reaction_rule":"WP_049586255.1 and WP_049586254.1",
 "annotation":{
 "bigg.reaction":[
 "OCOAT1",
@@ -39831,7 +39831,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09805",
+"gene_reaction_rule":"WP_049587346.1",
 "annotation":{
 "bigg.reaction":"MEPCT",
 "biocyc":"META:2.7.7.60-RXN",
@@ -39859,7 +39859,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03540",
+"gene_reaction_rule":"WP_039218556.1",
 "annotation":{
 "bigg.reaction":[
 "RBK1_2",
@@ -39890,7 +39890,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16115",
+"gene_reaction_rule":"WP_049588642.1",
 "annotation":{
 "bigg.reaction":[
 "HIS4_1",
@@ -39926,7 +39926,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02495",
+"gene_reaction_rule":"WP_049585952.1",
 "annotation":{
 "bigg.reaction":[
 "ERR2",
@@ -39960,7 +39960,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19275",
+"gene_reaction_rule":"WP_049589035.1",
 "annotation":{
 "bigg.reaction":"URCN",
 "biocyc":"META:UROCANATE-HYDRATASE-RXN",
@@ -39988,7 +39988,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17945 and TK37_RS17940",
+"gene_reaction_rule":"WP_014949014.1 and WP_049588855.1",
 "annotation":{
 "biocyc":"META:PRPPSYN-RXN",
 "ec-code":"2.7.6.1",
@@ -40014,7 +40014,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12125",
+"gene_reaction_rule":"WP_014979262.1",
 "annotation":{
 "bigg.reaction":[
 "SULabcpp",
@@ -40038,7 +40038,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03980",
+"gene_reaction_rule":"WP_014975732.1",
 "annotation":{
 "bigg.reaction":"HPDOAi",
 "ec-code":"1.5.1.34",
@@ -40062,7 +40062,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1E160pp",
 "ec-code":"3.1.1.5",
@@ -40083,7 +40083,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01050",
+"gene_reaction_rule":"WP_080986364.1",
 "annotation":{
 "bigg.reaction":[
 "NADDP",
@@ -40123,7 +40123,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02775",
+"gene_reaction_rule":"WP_080986374.1",
 "annotation":{
 "ec-code":[
 "2.5.1.31",
@@ -40146,7 +40146,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15545 or TK37_RS14410 or TK37_RS14505 or TK37_RS14410 or (TK37_RS03915 and TK37_RS02150) or (TK37_RS10830 and TK37_RS00840 and TK37_RS04490) or TK37_RS11700 or TK37_RS13230",
+"gene_reaction_rule":"WP_049588566.1 or WP_049588342.1 or WP_049588361.1 or WP_049588342.1 or (WP_014948348.1 and WP_049585898.1) or (WP_049587550.1 and WP_049585654.1 and WP_049586283.1) or WP_049587735.1 or WP_049588117.1",
 "annotation":{
 "bigg.reaction":[
 "NAt3pp",
@@ -40173,7 +40173,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12485",
+"gene_reaction_rule":"WP_049587964.1",
 "annotation":{
 "bigg.reaction":[
 "GCCam",
@@ -40204,7 +40204,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13640",
+"gene_reaction_rule":"WP_049588207.1",
 "annotation":{
 "ec-code":"1.4.7.1",
 "kegg.orthology":"K00284",
@@ -40226,7 +40226,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14210",
+"gene_reaction_rule":"WP_014948076.1",
 "annotation":{
 "ec-code":"4.1.1.65",
 "metanetx.reaction":"MNXR136230",
@@ -40246,7 +40246,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04445",
+"gene_reaction_rule":"WP_049586274.1",
 "annotation":{
 "bigg.reaction":[
 "PTE8x",
@@ -40282,7 +40282,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08045",
+"gene_reaction_rule":"WP_049586975.1",
 "annotation":{
 "bigg.reaction":[
 "ACSr",
@@ -40315,7 +40315,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10835",
+"gene_reaction_rule":"WP_049587551.1",
 "annotation":{
 "bigg.reaction":[
 "GLYBt2pp",
@@ -40340,7 +40340,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00590",
+"gene_reaction_rule":"WP_049585748.1",
 "annotation":{
 "bigg.reaction":"TTDCAt2",
 "metanetx.reaction":"MNXR136192",
@@ -40360,7 +40360,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08990",
+"gene_reaction_rule":"WP_014950261.1",
 "annotation":{
 "bigg.reaction":[
 "TMDK1",
@@ -40393,7 +40393,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13340",
+"gene_reaction_rule":"WP_049588136.1",
 "annotation":{
 "bigg.reaction":[
 "MNt2",
@@ -40417,7 +40417,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18640 and TK37_RS13800",
+"gene_reaction_rule":"WP_014949721.1 and WP_049588230.1",
 "annotation":{
 "bigg.reaction":[
 "ASPTAm",
@@ -40459,7 +40459,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01435",
+"gene_reaction_rule":"WP_049585822.1",
 "annotation":{
 "bigg.reaction":[
 "GSNt2r",
@@ -40486,7 +40486,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS10875 and TK37_RS08230 and TK37_RS09355 and TK37_RS20075 and TK37_RS17090 and TK37_RS04250 and TK37_RS08845 and TK37_RS18115 and TK37_RS09010) or TK37_RS18115",
+"gene_reaction_rule":"(WP_014947786.1 and WP_049587019.1 and WP_049587262.1 and WP_049589161.1 and WP_014949232.1 and WP_039227752.1 and WP_049587138.1 and WP_014976690.1 and WP_049587170.1) or WP_014976690.1",
 "annotation":{
 "bigg.reaction":"ACOAD6f",
 "ec-code":[
@@ -40520,7 +40520,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03950",
+"gene_reaction_rule":"WP_014948355.1",
 "annotation":{
 "bigg.reaction":"UAGCVT",
 "biocyc":"META:UDPNACETYLGLUCOSAMENOLPYRTRANS-RXN",
@@ -40547,7 +40547,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19680",
+"gene_reaction_rule":"WP_049589075.1",
 "annotation":{
 "bigg.reaction":[
 "DGGH",
@@ -40589,7 +40589,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07060 or TK37_RS07060",
+"gene_reaction_rule":"WP_049586790.1 or WP_049586790.1",
 "annotation":{
 "bigg.reaction":[
 "ACCOAL2r",
@@ -40622,7 +40622,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08435 and TK37_RS11220 and TK37_RS11660 and TK37_RS03755 and TK37_RS18545",
+"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
 "annotation":{
 "ec-code":"6.2.1.3",
 "metanetx.reaction":"MNXR134815",
@@ -40641,7 +40641,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06495",
+"gene_reaction_rule":"WP_039229483.1",
 "annotation":{
 "bigg.reaction":[
 "ADE13_1",
@@ -40671,7 +40671,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05020 and TK37_RS00825",
+"gene_reaction_rule":"WP_049586389.1 and WP_049585649.1",
 "annotation":{
 "bigg.reaction":"BG(CELLB)",
 "ec-code":[
@@ -40707,7 +40707,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06155",
+"gene_reaction_rule":"WP_049586630.1",
 "annotation":{
 "ec-code":"2.7.8.8",
 "metanetx.reaction":"MNXR136225",
@@ -40727,7 +40727,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15280",
+"gene_reaction_rule":"WP_014948150.1",
 "annotation":{
 "bigg.reaction":"GGTT",
 "biocyc":"META:RXN-8813",
@@ -40755,7 +40755,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06515",
+"gene_reaction_rule":"WP_049586716.1",
 "annotation":{
 "bigg.reaction":[
 "IDP1_1",
@@ -40781,7 +40781,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19680",
+"gene_reaction_rule":"WP_049589075.1",
 "annotation":{
 "bigg.reaction":[
 "YBR184W_3",
@@ -40814,7 +40814,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06025",
+"gene_reaction_rule":"WP_049586604.1",
 "annotation":{
 "bigg.reaction":[
 "PGPP120",
@@ -40839,7 +40839,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18130",
+"gene_reaction_rule":"WP_014976688.1",
 "annotation":{
 "bigg.reaction":[
 "ADE5_7_2",
@@ -40875,7 +40875,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15740",
+"gene_reaction_rule":"WP_049588613.1",
 "annotation":{
 "bigg.reaction":[
 "HOPNTAL",
@@ -40909,7 +40909,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1G120pp",
 "ec-code":"3.1.1.5",
@@ -40929,7 +40929,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14575 and TK37_RS05985",
+"gene_reaction_rule":"WP_049588376.1 and WP_049586601.1",
 "annotation":{
 "bigg.reaction":[
 "THFATm",
@@ -40955,7 +40955,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14500 and TK37_RS19730 and TK37_RS17765 and TK37_RS18690",
+"gene_reaction_rule":"WP_049588360.1 and WP_049589086.1 and WP_049588843.1 and WP_014976719.1",
 "annotation":{
 "bigg.reaction":[
 "GGTAe2",
@@ -40988,7 +40988,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00240",
+"gene_reaction_rule":"WP_049585742.1",
 "annotation":{
 "bigg.reaction":[
 "AICART",
@@ -41020,7 +41020,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11050",
+"gene_reaction_rule":"WP_014998709.1",
 "annotation":{
 "bigg.reaction":[
 "GND1",
@@ -41058,7 +41058,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02805",
+"gene_reaction_rule":"WP_014948562.1",
 "annotation":{
 "ec-code":"4.2.1.59",
 "metanetx.reaction":"MNXR134957",
@@ -41078,7 +41078,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2A140",
 "ec-code":"3.1.1.5",
@@ -41099,7 +41099,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07130",
+"gene_reaction_rule":"WP_049586810.1",
 "annotation":{
 "bigg.reaction":[
 "3HBUTDH",
@@ -41127,7 +41127,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06025",
+"gene_reaction_rule":"WP_049586604.1",
 "annotation":{
 "ec-code":"3.1.3.27",
 "metanetx.reaction":"MNXR136263",
@@ -41147,7 +41147,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07955",
+"gene_reaction_rule":"WP_014950808.1",
 "annotation":{
 "ec-code":"2.7.1.48",
 "kegg.reaction":"R01548",
@@ -41169,7 +41169,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS18165 and TK37_RS14390 and TK37_RS01810) or TK37_RS16445",
+"gene_reaction_rule":"(WP_049588882.1 and WP_012517074.1 and WP_049585862.1) or WP_049588677.1",
 "annotation":{
 "bigg.reaction":[
 "PASR",
@@ -41196,7 +41196,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02780",
+"gene_reaction_rule":"WP_014948557.1",
 "annotation":{
 "bigg.reaction":"DASYN181",
 "ec-code":"2.7.7.41",
@@ -41216,7 +41216,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13255 and TK37_RS18655",
+"gene_reaction_rule":"WP_049588124.1 and WP_041693510.1",
 "annotation":{
 "bigg.reaction":[
 "MET17_2",
@@ -41252,7 +41252,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19395",
+"gene_reaction_rule":"WP_014950978.1",
 "annotation":{
 "bigg.reaction":[
 "ME2m",
@@ -41283,7 +41283,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04095 and TK37_RS14380",
+"gene_reaction_rule":"WP_049586202.1 and WP_049588338.1",
 "annotation":{
 "bigg.reaction":[
 "NTD10pp",
@@ -41325,7 +41325,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17020",
+"gene_reaction_rule":"WP_049588748.1",
 "annotation":{
 "bigg.reaction":[
 "URA6_3",
@@ -41361,7 +41361,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19800",
+"gene_reaction_rule":"WP_049589098.1",
 "annotation":{
 "bigg.reaction":[
 "YPL275W",
@@ -41402,7 +41402,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06155",
+"gene_reaction_rule":"WP_049586630.1",
 "annotation":{
 "ec-code":"2.7.8.8",
 "metanetx.reaction":"MNXR136222",
@@ -41421,7 +41421,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05020 and TK37_RS00825",
+"gene_reaction_rule":"WP_049586389.1 and WP_049585649.1",
 "annotation":{
 "ec-code":"3.2.1.21",
 "metanetx.reaction":"MNXR96247",
@@ -41440,7 +41440,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02630",
+"gene_reaction_rule":"WP_014948529.1",
 "annotation":{
 "bigg.reaction":[
 "GLCNACPPUNDs",
@@ -41471,7 +41471,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04640",
+"gene_reaction_rule":"WP_012801201.1",
 "annotation":{
 "biocyc":"META:MERCURY-II-REDUCTASE-RXN",
 "ec-code":"1.16.1.1",
@@ -41497,7 +41497,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06155",
+"gene_reaction_rule":"WP_049586630.1",
 "annotation":{
 "bigg.reaction":"PSSA181",
 "ec-code":"2.7.8.8",
@@ -41520,7 +41520,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03330",
+"gene_reaction_rule":"WP_049586053.1",
 "annotation":{
 "biocyc":"META:6.3.2.10-RXN",
 "ec-code":"6.3.2.10",
@@ -41545,7 +41545,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09630 and TK37_RS08150",
+"gene_reaction_rule":"WP_049587320.1 and WP_049586999.1",
 "annotation":{
 "biocyc":"META:RXN-8675",
 "ec-code":"2.1.1.107",
@@ -41571,7 +41571,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14245",
+"gene_reaction_rule":"WP_014948069.1",
 "annotation":{
 "bigg.reaction":"RNDR4b",
 "metanetx.reaction":"MNXR104067",
@@ -41590,7 +41590,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03535",
+"gene_reaction_rule":"WP_014977204.1",
 "annotation":{
 "bigg.reaction":[
 "INSH",
@@ -41626,7 +41626,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560 or TK37_RS02805",
+"gene_reaction_rule":"WP_014949559.1 or WP_014948562.1",
 "annotation":{
 "bigg.reaction":[
 "3HAD120",
@@ -41665,7 +41665,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12110",
+"gene_reaction_rule":"WP_080752371.1",
 "annotation":{
 "bigg.reaction":[
 "DCYTD",
@@ -41701,7 +41701,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02830 or TK37_RS20110",
+"gene_reaction_rule":"WP_049585989.1 or WP_014949945.1",
 "annotation":{
 "bigg.reaction":[
 "ACCOACrm",
@@ -41751,7 +41751,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02780",
+"gene_reaction_rule":"WP_014948557.1",
 "annotation":{
 "bigg.reaction":"DASYN160",
 "ec-code":"2.7.7.41",
@@ -41771,7 +41771,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01855 or TK37_RS16315",
+"gene_reaction_rule":"WP_014976023.1 or WP_049588672.1",
 "annotation":{
 "bigg.reaction":[
 "PSCVTi",
@@ -41803,7 +41803,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12790",
+"gene_reaction_rule":"WP_049588021.1",
 "annotation":{
 "bigg.reaction":[
 "YNK1_6",
@@ -41839,7 +41839,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17010",
+"gene_reaction_rule":"WP_014949216.1",
 "annotation":{
 "bigg.reaction":[
 "ADCL",
@@ -41871,7 +41871,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19405",
+"gene_reaction_rule":"WP_014950980.1",
 "annotation":{
 "bigg.reaction":"MTHFR2",
 "biocyc":"META:1.5.1.20-RXN",
@@ -41902,7 +41902,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09025 or TK37_RS09025",
+"gene_reaction_rule":"WP_014950254.1 or WP_014950254.1",
 "annotation":{
 "biocyc":"META:LAUROYLACYLTRAN-RXN",
 "ec-code":[
@@ -41936,7 +41936,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04630 and TK37_RS10370 and TK37_RS00860 and TK37_RS04635",
+"gene_reaction_rule":"WP_045980005.1 and WP_012516887.1 and WP_039229202.1 and WP_045980004.1",
 "annotation":{
 "metanetx.reaction":"MNXR96498",
 "sbo":"SBO:0000655",
@@ -41955,7 +41955,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16705 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715",
+"gene_reaction_rule":"WP_049588707.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1",
 "annotation":{
 "bigg.reaction":[
 "HACD2i",
@@ -41995,7 +41995,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05800 or TK37_RS05800",
+"gene_reaction_rule":"WP_049586577.1 or WP_049586577.1",
 "annotation":{
 "biocyc":"META:ISPH2-RXN",
 "ec-code":"1.17.1.2",
@@ -42021,7 +42021,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15255 and TK37_RS01710 and TK37_RS17085",
+"gene_reaction_rule":"WP_024015658.1 and WP_049585851.1 and WP_049588755.1",
 "annotation":{
 "bigg.reaction":[
 "ACACT10rr",
@@ -42058,7 +42058,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07955",
+"gene_reaction_rule":"WP_014950808.1",
 "annotation":{
 "bigg.reaction":[
 "URIK2",
@@ -42085,7 +42085,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04400 and TK37_RS17370",
+"gene_reaction_rule":"WP_049586263.1 and WP_049588780.1",
 "annotation":{
 "bigg.reaction":[
 "ADCS",
@@ -42118,7 +42118,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04445",
+"gene_reaction_rule":"WP_049586274.1",
 "annotation":{
 "bigg.reaction":[
 "FACOAE160",
@@ -42155,7 +42155,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15645",
+"gene_reaction_rule":"WP_049588570.1",
 "annotation":{
 "bigg.reaction":[
 "VALTA",
@@ -42186,7 +42186,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18070 or TK37_RS16960",
+"gene_reaction_rule":"WP_049588870.1 or WP_049588741.1",
 "annotation":{
 "bigg.reaction":"PGLYCP",
 "biocyc":"META:GPH-RXN",
@@ -42218,7 +42218,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13645 and TK37_RS13655 and TK37_RS13650",
+"gene_reaction_rule":"WP_049588210.1 and WP_014949587.1 and WP_014949586.1",
 "annotation":{
 "bigg.reaction":"FEROpp",
 "biocyc":"META:RXN0-1483",
@@ -42254,7 +42254,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14510 or (TK37_RS14510 and TK37_RS05455)",
+"gene_reaction_rule":"WP_049588363.1 or (WP_049588363.1 and WP_049586557.1)",
 "annotation":{
 "bigg.reaction":"HXAD",
 "biocyc":"META:RXN-12625",
@@ -42283,7 +42283,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13515",
+"gene_reaction_rule":"WP_049588180.1",
 "annotation":{
 "bigg.reaction":[
 "NODO",
@@ -42311,7 +42311,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00335",
+"gene_reaction_rule":"WP_014951275.1",
 "annotation":{
 "bigg.reaction":[
 "DHQTi",
@@ -42346,7 +42346,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15280",
+"gene_reaction_rule":"WP_014948150.1",
 "annotation":{
 "bigg.reaction":[
 "PPTT",
@@ -42375,7 +42375,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06840",
+"gene_reaction_rule":"WP_049586760.1",
 "annotation":{
 "bigg.reaction":[
 "GLR1",
@@ -42412,7 +42412,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11415",
+"gene_reaction_rule":"WP_014948685.1",
 "annotation":{
 "bigg.reaction":"PHE4MOi3",
 "ec-code":"1.14.16.1",
@@ -42436,7 +42436,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14220",
+"gene_reaction_rule":"WP_049588313.1",
 "annotation":{
 "bigg.reaction":[
 "GPDDA3pp",
@@ -42462,7 +42462,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16075",
+"gene_reaction_rule":"WP_049588635.1",
 "annotation":{
 "bigg.reaction":[
 "DADK",
@@ -42496,7 +42496,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03865",
+"gene_reaction_rule":"WP_014948339.1",
 "annotation":{
 "bigg.reaction":[
 "GLCpts",
@@ -42519,7 +42519,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14890 or TK37_RS17000",
+"gene_reaction_rule":"WP_014951390.1 or WP_012518211.1",
 "annotation":{
 "bigg.reaction":"G3PAT141",
 "ec-code":"2.3.1.15",
@@ -42540,7 +42540,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14845",
+"gene_reaction_rule":"WP_049588438.1",
 "annotation":{
 "bigg.reaction":[
 "GUT1",
@@ -42570,7 +42570,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08140 and TK37_RS08135",
+"gene_reaction_rule":"WP_014975661.1 and WP_049586997.1",
 "annotation":{
 "bigg.reaction":[
 "NTRIRy",
@@ -42603,7 +42603,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16995",
+"gene_reaction_rule":"WP_014976326.1",
 "annotation":{
 "bigg.reaction":[
 "HOCR3",
@@ -42634,7 +42634,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06735 or TK37_RS06735",
+"gene_reaction_rule":"WP_049586772.1 or WP_049586772.1",
 "annotation":{
 "bigg.reaction":"OPHBDC",
 "biocyc":"META:3-OCTAPRENYL-4-OHBENZOATE-DECARBOX-RXN",
@@ -42664,7 +42664,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03445 or (TK37_RS01080 and TK37_RS13150)",
+"gene_reaction_rule":"WP_049586083.1 or (WP_049585701.1 and WP_049588105.1)",
 "annotation":{
 "bigg.reaction":"AM4PA",
 "metanetx.reaction":"MNXR95793",
@@ -42683,7 +42683,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14890",
+"gene_reaction_rule":"WP_014951390.1",
 "annotation":{
 "ec-code":"2.3.1.15",
 "metanetx.reaction":"MNXR136203",
@@ -42702,7 +42702,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16420 or (TK37_RS00505 and TK37_RS00500 and TK37_RS00495)",
+"gene_reaction_rule":"WP_014950712.1 or (WP_014951244.1 and WP_014951245.1 and WP_049585562.1)",
 "annotation":{
 "bigg.reaction":[
 "THD5",
@@ -42738,7 +42738,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18835 and TK37_RS12090",
+"gene_reaction_rule":"WP_049588976.1 and WP_049587837.1",
 "annotation":{
 "bigg.reaction":"SGDS",
 "biocyc":"META:SUCCGLUDESUCC-RXN",
@@ -42762,7 +42762,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12610 and TK37_RS15400 and TK37_RS03220 and TK37_RS19185 and TK37_RS01765",
+"gene_reaction_rule":"WP_049587995.1 and WP_049588550.1 and WP_049586043.1 and WP_014949867.1 and WP_049585855.1",
 "annotation":{
 "bigg.reaction":[
 "ALKP",
@@ -42795,7 +42795,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14890",
+"gene_reaction_rule":"WP_014951390.1",
 "annotation":{
 "ec-code":"2.3.1.15",
 "metanetx.reaction":"MNXR99858",
@@ -42815,7 +42815,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19135",
+"gene_reaction_rule":"WP_049589016.1",
 "annotation":{
 "bigg.reaction":"MANAO",
 "ec-code":"1.1.1.57",
@@ -42836,7 +42836,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06200",
+"gene_reaction_rule":"WP_049586648.1",
 "annotation":{
 "bigg.reaction":"4AHD2",
 "ec-code":"4.2.1.96",
@@ -42859,7 +42859,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05595 or (TK37_RS15255 and TK37_RS01710 and TK37_RS17085) or TK37_RS17085",
+"gene_reaction_rule":"WP_049586525.1 or (WP_024015658.1 and WP_049585851.1 and WP_049588755.1) or WP_049588755.1",
 "annotation":{
 "bigg.reaction":[
 "ACACT2r",
@@ -42898,7 +42898,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18480",
+"gene_reaction_rule":"WP_014950158.1",
 "annotation":{
 "bigg.reaction":[
 "PUR5",
@@ -42934,7 +42934,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11065",
+"gene_reaction_rule":"WP_049587602.1",
 "annotation":{
 "bigg.reaction":[
 "GAPD(nadp)",
@@ -42970,7 +42970,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02670",
+"gene_reaction_rule":"WP_049585972.1",
 "annotation":{
 "biocyc":"META:RXN-14065",
 "ec-code":"3.2.2.10",
@@ -42994,7 +42994,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18850",
+"gene_reaction_rule":"WP_049588979.1",
 "annotation":{
 "bigg.reaction":[
 "PGM1_2",
@@ -43040,7 +43040,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00755",
+"gene_reaction_rule":"WP_049585628.1",
 "annotation":{
 "bigg.reaction":"HCYSMT2",
 "biocyc":"META:MMUM-RXN",
@@ -43067,7 +43067,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17600 and TK37_RS14480",
+"gene_reaction_rule":"WP_014950684.1 and WP_049588355.1",
 "annotation":{
 "biocyc":"META:RXN-14209",
 "ec-code":"1.2.1.3",
@@ -43096,7 +43096,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08435 and TK37_RS11220 and TK37_RS11660 and TK37_RS03755 and TK37_RS18545",
+"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
 "annotation":{
 "ec-code":"6.2.1.3",
 "metanetx.reaction":"MNXR134820",
@@ -43116,7 +43116,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14205",
+"gene_reaction_rule":"WP_039219288.1",
 "annotation":{
 "bigg.reaction":[
 "NTP3pp",
@@ -43168,7 +43168,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02750 or (TK37_RS13980 and TK37_RS20685) or (TK37_RS04495 and TK37_RS07675) or TK37_RS05630 or TK37_RS18985 or TK37_RS05630",
+"gene_reaction_rule":"WP_049585982.1 or (WP_014999437.1 and WP_053103828.1) or (WP_049586284.1 and WP_080986400.1) or WP_049586533.1 or WP_049589000.1 or WP_049586533.1",
 "annotation":{
 "bigg.reaction":"MEAMP1(ala-his)",
 "biocyc":"META:RXN0-6978",
@@ -43193,7 +43193,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08055 and TK37_RS13360",
+"gene_reaction_rule":"WP_049586976.1 and WP_049588150.1",
 "annotation":{
 "bigg.reaction":[
 "PIt8",
@@ -43217,7 +43217,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04710",
+"gene_reaction_rule":"WP_080986386.1",
 "annotation":{
 "ec-code":"2.7.8.12",
 "metanetx.reaction":"MNXR136291",
@@ -43237,7 +43237,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01850 and TK37_RS02220",
+"gene_reaction_rule":"WP_014948838.1 and WP_014978802.1",
 "annotation":{
 "bigg.reaction":[
 "DDPAm",
@@ -43275,7 +43275,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07955",
+"gene_reaction_rule":"WP_014950808.1",
 "annotation":{
 "ec-code":"2.7.1.48",
 "kegg.reaction":"R02091",
@@ -43295,7 +43295,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04045",
+"gene_reaction_rule":"WP_049586189.1",
 "annotation":{
 "bigg.reaction":"TKT2",
 "ec-code":"2.2.1.1",
@@ -43318,7 +43318,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12810 and TK37_RS12805",
+"gene_reaction_rule":"WP_049588028.1 and WP_049588027.1",
 "annotation":{
 "bigg.reaction":[
 "METS",
@@ -43358,7 +43358,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03720",
+"gene_reaction_rule":"WP_049586139.1",
 "annotation":{
 "bigg.reaction":"NTPP1",
 "biocyc":[
@@ -43389,7 +43389,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06030",
+"gene_reaction_rule":"WP_049586605.1",
 "annotation":{
 "bigg.reaction":"DXPS",
 "biocyc":"META:DXS-RXN",
@@ -43417,7 +43417,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05250 and TK37_RS03515 and TK37_RS13260",
+"gene_reaction_rule":"WP_049586436.1 and WP_049586098.1 and WP_049588126.1",
 "annotation":{
 "bigg.reaction":[
 "SER3",
@@ -43449,7 +43449,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19710",
+"gene_reaction_rule":"WP_049589081.1",
 "annotation":{
 "bigg.reaction":[
 "GALT",
@@ -43484,7 +43484,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02870",
+"gene_reaction_rule":"WP_049585995.1",
 "annotation":{
 "bigg.reaction":[
 "PRFGS",
@@ -43521,7 +43521,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00090 or TK37_RS00090",
+"gene_reaction_rule":"WP_014951320.1 or WP_014951320.1",
 "annotation":{
 "bigg.reaction":"NTP10",
 "biocyc":[
@@ -43560,7 +43560,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14210",
+"gene_reaction_rule":"WP_014948076.1",
 "annotation":{
 "ec-code":"4.1.1.65",
 "metanetx.reaction":"MNXR136229",
@@ -43580,7 +43580,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12495 and TK37_RS12490",
+"gene_reaction_rule":"WP_049587956.1 and WP_014950360.1",
 "annotation":{
 "bigg.reaction":[
 "GCCb",
@@ -43610,7 +43610,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15550",
+"gene_reaction_rule":"WP_049588567.1",
 "annotation":{
 "bigg.reaction":"MOAT2",
 "biocyc":"META:KDOTRANS2-RXN",
@@ -43641,7 +43641,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11015",
+"gene_reaction_rule":"WP_049587592.1",
 "annotation":{
 "bigg.reaction":[
 "HXK1_2",
@@ -43682,7 +43682,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1E180pp",
 "ec-code":"3.1.1.5",
@@ -43700,7 +43700,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03070",
+"gene_reaction_rule":"WP_049586025.1",
 "annotation":{
 "bigg.reaction":[
 "PGI",
@@ -43730,7 +43730,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02750 or (TK37_RS13980 and TK37_RS20685) or (TK37_RS04495 and TK37_RS07675) or TK37_RS05630 or TK37_RS18985 or TK37_RS05630",
+"gene_reaction_rule":"WP_049585982.1 or (WP_014999437.1 and WP_053103828.1) or (WP_049586284.1 and WP_080986400.1) or WP_049586533.1 or WP_049589000.1 or WP_049586533.1",
 "annotation":{
 "bigg.reaction":"MEAMP1(gly-met)",
 "biocyc":"META:RXN0-6974",
@@ -43752,7 +43752,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18815 and TK37_RS19920",
+"gene_reaction_rule":"WP_080986474.1 and WP_049589117.1",
 "annotation":{
 "bigg.reaction":[
 "GLUt2n",
@@ -43780,7 +43780,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18945",
+"gene_reaction_rule":"WP_014977595.1",
 "annotation":{
 "bigg.reaction":[
 "GLUDC",
@@ -43810,7 +43810,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15645",
+"gene_reaction_rule":"WP_049588570.1",
 "annotation":{
 "bigg.reaction":[
 "LEUTA",
@@ -43848,7 +43848,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07910",
+"gene_reaction_rule":"WP_049586958.1",
 "annotation":{
 "ec-code":"1.3.1.9",
 "kegg.orthology":[
@@ -43873,7 +43873,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560 or TK37_RS02805",
+"gene_reaction_rule":"WP_014949559.1 or WP_014948562.1",
 "annotation":{
 "ec-code":"4.2.1.0",
 "metanetx.reaction":"MNXR134858",
@@ -43894,7 +43894,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17600 and TK37_RS14480",
+"gene_reaction_rule":"WP_014950684.1 and WP_049588355.1",
 "annotation":{
 "bigg.reaction":[
 "U68",
@@ -43937,7 +43937,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07645",
+"gene_reaction_rule":"WP_049586907.1",
 "annotation":{
 "bigg.reaction":[
 "ALD4_2",
@@ -43983,7 +43983,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08435 and TK37_RS11220 and TK37_RS11660 and TK37_RS03755 and TK37_RS18545",
+"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
 "annotation":{
 "bigg.reaction":"FACOAL180",
 "biocyc":[
@@ -44008,7 +44008,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07910",
+"gene_reaction_rule":"WP_049586958.1",
 "annotation":{
 "ec-code":"1.3.1.9",
 "kegg.orthology":[
@@ -44032,7 +44032,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03860 and TK37_RS08625",
+"gene_reaction_rule":"WP_014948338.1 and WP_014977961.1",
 "annotation":{
 "bigg.reaction":[
 "MG2tpp",
@@ -44059,7 +44059,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1E141pp",
 "ec-code":"3.1.1.5",
@@ -44079,7 +44079,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04095 and TK37_RS14380",
+"gene_reaction_rule":"WP_049586202.1 and WP_049588338.1",
 "annotation":{
 "bigg.reaction":[
 "NTD6",
@@ -44118,7 +44118,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14860 or (TK37_RS02020 and TK37_RS15840 and TK37_RS01380)",
+"gene_reaction_rule":"WP_014951396.1 or (WP_049585878.1 and WP_152910898.1 and WP_049585810.1)",
 "annotation":{
 "bigg.reaction":[
 "PAN5",
@@ -44156,7 +44156,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08125",
+"gene_reaction_rule":"WP_014978293.1",
 "annotation":{
 "bigg.reaction":[
 "SO4t2",
@@ -44180,7 +44180,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07145",
+"gene_reaction_rule":"WP_014948959.1",
 "annotation":{
 "bigg.reaction":[
 "NADK",
@@ -44215,7 +44215,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS03615 and TK37_RS08450) or TK37_RS15625",
+"gene_reaction_rule":"(WP_049586123.1 and WP_049587064.1) or WP_049588568.1",
 "annotation":{
 "bigg.reaction":"ACONTb",
 "ec-code":"4.2.1.3",
@@ -44243,7 +44243,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00545",
+"gene_reaction_rule":"WP_049585574.1",
 "annotation":{
 "bigg.reaction":[
 "G1PACT",
@@ -44276,7 +44276,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02630",
+"gene_reaction_rule":"WP_014948529.1",
 "annotation":{
 "ec-code":"2.7.8.-",
 "metanetx.reaction":"MNXR136305",
@@ -44297,7 +44297,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08435 and TK37_RS11220 and TK37_RS11660 and TK37_RS03755 and TK37_RS18545",
+"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
 "annotation":{
 "ec-code":"6.2.1.3",
 "metanetx.reaction":"MNXR134817",
@@ -44316,7 +44316,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09630 and TK37_RS08150",
+"gene_reaction_rule":"WP_049587320.1 and WP_049586999.1",
 "annotation":{
 "bigg.reaction":"SHCHF",
 "biocyc":"META:SIROHEME-FERROCHELAT-RXN",
@@ -44348,7 +44348,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10765",
+"gene_reaction_rule":"WP_049587537.1",
 "annotation":{
 "bigg.reaction":"THRD",
 "biocyc":"META:THREODEHYD-RXN",
@@ -44381,7 +44381,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02195",
+"gene_reaction_rule":"WP_049585905.1",
 "annotation":{
 "bigg.reaction":[
 "DBTS",
@@ -44415,7 +44415,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02295",
+"gene_reaction_rule":"WP_049585927.1",
 "annotation":{
 "biocyc":"META:3.5.1.80-RXN",
 "ec-code":"3.5.1.25",
@@ -44442,7 +44442,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02780",
+"gene_reaction_rule":"WP_014948557.1",
 "annotation":{
 "ec-code":"2.7.7.41",
 "metanetx.reaction":"MNXR136219",
@@ -44461,7 +44461,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19680",
+"gene_reaction_rule":"WP_049589075.1",
 "annotation":{
 "bigg.reaction":"GALS4",
 "ec-code":"3.2.1.22",
@@ -44489,7 +44489,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05565",
+"gene_reaction_rule":"WP_080986391.1",
 "annotation":{
 "bigg.reaction":"HMGL",
 "biocyc":"META:HYDROXYMETHYLGLUTARYL-COA-LYASE-RXN",
@@ -44516,7 +44516,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13780",
+"gene_reaction_rule":"WP_049588224.1",
 "annotation":{
 "ec-code":"2.7.8.5",
 "metanetx.reaction":"MNXR136256",
@@ -44536,7 +44536,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16705 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715",
+"gene_reaction_rule":"WP_049588707.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1",
 "annotation":{
 "bigg.reaction":[
 "HACD5",
@@ -44575,7 +44575,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04250",
+"gene_reaction_rule":"WP_039227752.1",
 "annotation":{
 "bigg.reaction":"2MACOAD",
 "biocyc":"META:MEPROPCOA-FAD-RXN",
@@ -44598,7 +44598,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12110",
+"gene_reaction_rule":"WP_080752371.1",
 "annotation":{
 "bigg.reaction":[
 "CYTD",
@@ -44630,7 +44630,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03360",
+"gene_reaction_rule":"WP_049586061.1",
 "annotation":{
 "bigg.reaction":[
 "ALAALAr",
@@ -44658,7 +44658,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17630",
+"gene_reaction_rule":"WP_085929484.1",
 "annotation":{
 "bigg.reaction":[
 "HIBDkt",
@@ -44687,7 +44687,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03720",
+"gene_reaction_rule":"WP_049586139.1",
 "annotation":{
 "bigg.reaction":"NTPP2",
 "biocyc":[
@@ -44720,7 +44720,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14210",
+"gene_reaction_rule":"WP_014948076.1",
 "annotation":{
 "bigg.reaction":"PSD141",
 "ec-code":"4.1.1.65",
@@ -44741,7 +44741,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS18165 and TK37_RS14390 and TK37_RS01810) or (TK37_RS16295 and TK37_RS16290)",
+"gene_reaction_rule":"(WP_049588882.1 and WP_012517074.1 and WP_049585862.1) or (WP_014949648.1 and WP_014949649.1)",
 "annotation":{
 "bigg.reaction":[
 "RNDR2",
@@ -44775,7 +44775,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13780",
+"gene_reaction_rule":"WP_049588224.1",
 "annotation":{
 "bigg.reaction":"PGSA140",
 "ec-code":"2.7.8.5",
@@ -44795,7 +44795,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13345",
+"gene_reaction_rule":"WP_014950659.1",
 "annotation":{
 "bigg.reaction":[
 "AHCi",
@@ -44827,7 +44827,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18245",
+"gene_reaction_rule":"WP_049588898.1",
 "annotation":{
 "bigg.reaction":"TDPDRR",
 "biocyc":"META:DTDPDEHYRHAMREDUCT-RXN",
@@ -44858,7 +44858,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04045",
+"gene_reaction_rule":"WP_049586189.1",
 "annotation":{
 "biocyc":"META:1TRANSKETO-RXN",
 "ec-code":"2.2.1.1",
@@ -44882,7 +44882,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16935",
+"gene_reaction_rule":"WP_049588737.1",
 "annotation":{
 "bigg.reaction":[
 "SFGTHi",
@@ -44913,7 +44913,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14835",
+"gene_reaction_rule":"WP_049588435.1",
 "annotation":{
 "bigg.reaction":"G3PD7",
 "biocyc":"META:RXN0-5260",
@@ -44938,7 +44938,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03470",
+"gene_reaction_rule":"WP_049586089.1",
 "annotation":{
 "bigg.reaction":[
 "LPD1",
@@ -44971,7 +44971,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560 or TK37_RS02805",
+"gene_reaction_rule":"WP_014949559.1 or WP_014948562.1",
 "annotation":{
 "bigg.reaction":"3HAD160",
 "ec-code":"4.2.1.59",
@@ -45003,7 +45003,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06020",
+"gene_reaction_rule":"WP_014950086.1",
 "annotation":{
 "bigg.reaction":[
 "TMPKr",
@@ -45035,7 +45035,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15975 and TK37_RS15980 and TK37_RS15985 and TK37_RS15990",
+"gene_reaction_rule":"WP_012518362.1 and WP_014949447.1 and WP_014949446.1 and WP_014949445.1",
 "annotation":{
 "bigg.reaction":[
 "FRD",
@@ -45067,7 +45067,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09780 and TK37_RS13445 and TK37_RS18295 and TK37_RS07135 and TK37_RS17935",
+"gene_reaction_rule":"WP_049587342.1 and WP_014977336.1 and WP_049588907.1 and WP_049586860.1 and WP_049588854.1",
 "annotation":{
 "bigg.reaction":"ALCD19",
 "biocyc":"META:RXN-11709",
@@ -45097,7 +45097,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14890",
+"gene_reaction_rule":"WP_014951390.1",
 "annotation":{
 "bigg.reaction":"G3PAT161",
 "ec-code":"2.3.1.15",
@@ -45117,7 +45117,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19680",
+"gene_reaction_rule":"WP_049589075.1",
 "annotation":{
 "bigg.reaction":[
 "YBR184W_6",
@@ -45148,7 +45148,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18385",
+"gene_reaction_rule":"WP_049588920.1",
 "annotation":{
 "bigg.reaction":[
 "TREH",
@@ -45189,7 +45189,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1G140pp",
 "ec-code":"3.1.1.5",
@@ -45208,7 +45208,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16135",
+"gene_reaction_rule":"WP_049588646.1",
 "annotation":{
 "bigg.reaction":"IGPDH",
 "biocyc":"META:IMIDPHOSDEHYD-RXN",
@@ -45239,7 +45239,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07835",
+"gene_reaction_rule":"WP_039216382.1",
 "annotation":{
 "bigg.reaction":[
 "GNKr",
@@ -45272,7 +45272,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07410",
+"gene_reaction_rule":"WP_049586874.1",
 "annotation":{
 "ec-code":"2.4.1.7",
 "kegg.orthology":"K00690",
@@ -45297,7 +45297,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02630",
+"gene_reaction_rule":"WP_014948529.1",
 "annotation":{
 "ec-code":"2.7.8.-",
 "metanetx.reaction":"MNXR136311",
@@ -45319,7 +45319,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14340",
+"gene_reaction_rule":"WP_049588329.1",
 "annotation":{
 "biocyc":"META:ARGSUCCINSYN-RXN",
 "ec-code":"6.3.4.5",
@@ -45349,7 +45349,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18955",
+"gene_reaction_rule":"WP_014977593.1",
 "annotation":{
 "bigg.reaction":[
 "ECM31",
@@ -45381,7 +45381,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14245",
+"gene_reaction_rule":"WP_014948069.1",
 "annotation":{
 "bigg.reaction":"PAPSR2",
 "ec-code":"1.8.4.8",
@@ -45402,7 +45402,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2A141",
 "ec-code":"3.1.1.5",
@@ -45420,7 +45420,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17080 and TK37_RS15260 and TK37_RS01715",
+"gene_reaction_rule":"WP_049588754.1 and WP_049588521.1 and WP_049585918.1",
 "annotation":{
 "ec-code":"5.1.2.3",
 "kegg.orthology":[
@@ -45443,7 +45443,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12045 and TK37_RS16635",
+"gene_reaction_rule":"WP_049587825.1 and WP_014949348.1",
 "annotation":{
 "bigg.reaction":"MDDEP4pp",
 "metanetx.reaction":"MNXR101437",
@@ -45462,7 +45462,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05780",
+"gene_reaction_rule":"WP_014950132.1",
 "annotation":{
 "bigg.reaction":[
 "FMNATr",
@@ -45500,7 +45500,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05020 and TK37_RS00825",
+"gene_reaction_rule":"WP_049586389.1 and WP_049585649.1",
 "annotation":{
 "ec-code":"3.2.1.21",
 "metanetx.reaction":"MNXR96248",
@@ -45520,7 +45520,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16295 and TK37_RS16290",
+"gene_reaction_rule":"WP_014949648.1 and WP_014949649.1",
 "annotation":{
 "bigg.reaction":[
 "RNDR3",
@@ -45554,7 +45554,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12045 and TK37_RS16635",
+"gene_reaction_rule":"WP_049587825.1 and WP_014949348.1",
 "annotation":{
 "bigg.reaction":"MDDCP1pp",
 "ec-code":"3.4.16.4",
@@ -45574,7 +45574,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10360 and TK37_RS13625",
+"gene_reaction_rule":"WP_015066029.1 and WP_014976618.1",
 "annotation":{
 "bigg.reaction":"DAGK120",
 "ec-code":"2.7.1.107",
@@ -45597,7 +45597,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06150",
+"gene_reaction_rule":"WP_049586628.1",
 "annotation":{
 "bigg.reaction":[
 "ILEabc",
@@ -45624,7 +45624,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13780",
+"gene_reaction_rule":"WP_049588224.1",
 "annotation":{
 "ec-code":"2.7.8.5",
 "metanetx.reaction":"MNXR136255",
@@ -45644,7 +45644,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS17265 and TK37_RS17800) or TK37_RS09840",
+"gene_reaction_rule":"(WP_049588769.1 and WP_049588847.1) or WP_039231980.1",
 "annotation":{
 "bigg.reaction":[
 "FOLR2",
@@ -45679,7 +45679,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14860 or TK37_RS14860 or TK37_RS14860",
+"gene_reaction_rule":"WP_014951396.1 or WP_014951396.1 or WP_014951396.1",
 "annotation":{
 "ec-code":"1.1.1.86",
 "kegg.orthology":"K00053",
@@ -45702,7 +45702,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15165",
+"gene_reaction_rule":"WP_049588489.1",
 "annotation":{
 "bigg.reaction":"RMI",
 "biocyc":"META:RHAMNISOM-RXN",
@@ -45727,7 +45727,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15625",
+"gene_reaction_rule":"WP_049588568.1",
 "annotation":{
 "bigg.reaction":[
 "MICITDr",
@@ -45763,7 +45763,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19910",
+"gene_reaction_rule":"WP_049589115.1",
 "annotation":{
 "bigg.reaction":"SADH",
 "biocyc":"META:SUCCARGDIHYDRO-RXN",
@@ -45795,7 +45795,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16985 or TK37_RS11900 or TK37_RS17005",
+"gene_reaction_rule":"WP_014949212.1 or WP_014949953.1 or WP_049588746.1",
 "annotation":{
 "bigg.reaction":[
 "MCMAT7",
@@ -45829,7 +45829,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18685 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715 and TK37_RS11765 and TK37_RS01845",
+"gene_reaction_rule":"WP_049588954.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1 and WP_014976911.1 and WP_014948837.1",
 "annotation":{
 "bigg.reaction":[
 "ECOAH6p",
@@ -45867,7 +45867,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04095 and TK37_RS14380",
+"gene_reaction_rule":"WP_049586202.1 and WP_049588338.1",
 "annotation":{
 "bigg.reaction":[
 "NTD1",
@@ -45908,7 +45908,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02750 or (TK37_RS13980 and TK37_RS20685) or (TK37_RS04495 and TK37_RS07675) or TK37_RS05630 or TK37_RS18985 or TK37_RS05630",
+"gene_reaction_rule":"WP_049585982.1 or (WP_014999437.1 and WP_053103828.1) or (WP_049586284.1 and WP_080986400.1) or WP_049586533.1 or WP_049589000.1 or WP_049586533.1",
 "annotation":{
 "bigg.reaction":"MEAMP1(met-ala)",
 "metanetx.reaction":"MNXR137141",
@@ -45930,7 +45930,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03565",
+"gene_reaction_rule":"WP_049586106.1",
 "annotation":{
 "biocyc":"META:2-OCTAPRENYLPHENOL-HYDROX-RXN",
 "ec-code":"1.14.13.-",
@@ -45957,7 +45957,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07645",
+"gene_reaction_rule":"WP_049586907.1",
 "annotation":{
 "bigg.reaction":"ALR2",
 "biocyc":"META:RXN0-4281",
@@ -45985,7 +45985,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00090 or TK37_RS00090",
+"gene_reaction_rule":"WP_014951320.1 or WP_014951320.1",
 "annotation":{
 "bigg.reaction":"NTP12",
 "biocyc":"META:RXN0-5074",
@@ -46008,7 +46008,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11430 and TK37_RS15725 and TK37_RS13265",
+"gene_reaction_rule":"WP_014975930.1 and WP_080986455.1 and WP_049588128.1",
 "annotation":{
 "bigg.reaction":[
 "MACACI",
@@ -46040,7 +46040,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05895",
+"gene_reaction_rule":"WP_014976996.1",
 "annotation":{
 "bigg.reaction":"ASPO6",
 "biocyc":"META:L-ASPARTATE-OXID-RXN",
@@ -46069,7 +46069,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11960",
+"gene_reaction_rule":"WP_039229394.1",
 "annotation":{
 "bigg.reaction":"G5SD",
 "biocyc":"META:GLUTSEMIALDEHYDROG-RXN",
@@ -46098,7 +46098,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17695",
+"gene_reaction_rule":"WP_049588830.1",
 "annotation":{
 "bigg.reaction":[
 "OP4ENH",
@@ -46130,7 +46130,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17275",
+"gene_reaction_rule":"WP_039229281.1",
 "annotation":{
 "bigg.reaction":"AMID5",
 "biocyc":"META:R311-RXN",
@@ -46159,7 +46159,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13160 and TK37_RS05520 and TK37_RS13155 and TK37_RS04190",
+"gene_reaction_rule":"WP_012519580.1 and WP_049586503.1 and WP_014950543.1 and WP_014975770.1",
 "annotation":{
 "bigg.reaction":"GLUSy",
 "biocyc":"META:GLUTAMATESYN-RXN",
@@ -46191,7 +46191,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02765",
+"gene_reaction_rule":"WP_014948554.1",
 "annotation":{
 "bigg.reaction":[
 "UMPKn",
@@ -46264,7 +46264,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07955",
+"gene_reaction_rule":"WP_014950808.1",
 "annotation":{
 "bigg.reaction":[
 "URK1_3",
@@ -46295,7 +46295,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04425 and TK37_RS04420",
+"gene_reaction_rule":"WP_049586269.1 and WP_049586267.1",
 "annotation":{
 "ec-code":"1.2.4.4",
 "kegg.orthology":[
@@ -46322,7 +46322,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03640",
+"gene_reaction_rule":"WP_049586127.1",
 "annotation":{
 "bigg.reaction":"GP4GH",
 "metanetx.reaction":"MNXR100398",
@@ -46342,7 +46342,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03720",
+"gene_reaction_rule":"WP_049586139.1",
 "annotation":{
 "bigg.reaction":"NTPP6",
 "biocyc":[
@@ -46375,7 +46375,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17515",
+"gene_reaction_rule":"WP_014976192.1",
 "annotation":{
 "biocyc":"META:3.5.2.17-RXN",
 "ec-code":"3.5.2.17",
@@ -46405,7 +46405,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15735",
+"gene_reaction_rule":"WP_049588587.1",
 "annotation":{
 "bigg.reaction":"TARTDC",
 "biocyc":"META:TARTRATE-DECARBOXYLASE-RXN",
@@ -46433,7 +46433,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14890 or TK37_RS17000",
+"gene_reaction_rule":"WP_014951390.1 or WP_012518211.1",
 "annotation":{
 "bigg.reaction":"G3PAT160",
 "ec-code":"2.3.1.15",
@@ -46454,7 +46454,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06035",
+"gene_reaction_rule":"WP_014950084.1",
 "annotation":{
 "bigg.reaction":"GRTT",
 "biocyc":"META:FPPSYN-RXN",
@@ -46487,7 +46487,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13185 and TK37_RS02210",
+"gene_reaction_rule":"WP_049588138.1 and WP_049585906.1",
 "annotation":{
 "metanetx.reaction":"MNXR125940",
 "sbo":"SBO:0000655",
@@ -46506,7 +46506,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04710",
+"gene_reaction_rule":"WP_080986386.1",
 "annotation":{
 "ec-code":"2.7.8.12",
 "metanetx.reaction":"MNXR136286",
@@ -46525,7 +46525,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12815",
+"gene_reaction_rule":"WP_039224879.1",
 "annotation":{
 "bigg.reaction":[
 "HSSTr",
@@ -46561,7 +46561,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13910",
+"gene_reaction_rule":"WP_014980177.1",
 "annotation":{
 "bigg.reaction":"GLNSP3",
 "ec-code":"6.3.1.2",
@@ -46582,7 +46582,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07955",
+"gene_reaction_rule":"WP_014950808.1",
 "annotation":{
 "ec-code":"2.7.1.48",
 "kegg.reaction":"R02327",
@@ -46601,7 +46601,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS03615 and TK37_RS08450) or TK37_RS15625",
+"gene_reaction_rule":"(WP_049586123.1 and WP_049587064.1) or WP_049588568.1",
 "annotation":{
 "bigg.reaction":"ACONTa",
 "biocyc":[
@@ -46638,7 +46638,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03340",
+"gene_reaction_rule":"WP_049586054.1",
 "annotation":{
 "bigg.reaction":"UAMAGS",
 "biocyc":"META:UDP-NACMURALA-GLU-LIG-RXN",
@@ -46668,7 +46668,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18845",
+"gene_reaction_rule":"WP_049588978.1",
 "annotation":{
 "bigg.reaction":[
 "GLC3",
@@ -46690,7 +46690,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14210",
+"gene_reaction_rule":"WP_014948076.1",
 "annotation":{
 "bigg.reaction":"PSD181",
 "ec-code":"4.1.1.65",
@@ -46710,7 +46710,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03335",
+"gene_reaction_rule":"WP_014950432.1",
 "annotation":{
 "bigg.reaction":"PAPPT3",
 "biocyc":"META:PHOSNACMURPENTATRANS-RXN",
@@ -46741,7 +46741,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17510",
+"gene_reaction_rule":"WP_049588801.1",
 "annotation":{
 "bigg.reaction":[
 "GUAD",
@@ -46772,7 +46772,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07955",
+"gene_reaction_rule":"WP_014950808.1",
 "annotation":{
 "ec-code":"2.7.1.48",
 "kegg.reaction":"R02332",
@@ -46792,7 +46792,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01055",
+"gene_reaction_rule":"WP_014951100.1",
 "annotation":{
 "bigg.reaction":"UPPDC1",
 "biocyc":"META:UROGENDECARBOX-RXN",
@@ -46819,7 +46819,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17295 and TK37_RS15485",
+"gene_reaction_rule":"WP_049588772.1 and WP_049588556.1",
 "annotation":{
 "metanetx.reaction":"MNXR136199",
 "sbo":"SBO:0000176",
@@ -46837,7 +46837,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12790",
+"gene_reaction_rule":"WP_049588021.1",
 "annotation":{
 "bigg.reaction":[
 "YNK1_2",
@@ -46874,7 +46874,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04710",
+"gene_reaction_rule":"WP_080986386.1",
 "annotation":{
 "ec-code":"2.7.8.12",
 "metanetx.reaction":"MNXR136194",
@@ -46896,7 +46896,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17000",
+"gene_reaction_rule":"WP_012518211.1",
 "annotation":{
 "bigg.reaction":"AACPS2",
 "ec-code":"6.2.1.20",
@@ -46917,7 +46917,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2E161",
 "ec-code":"3.1.1.5",
@@ -46939,7 +46939,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05930 and TK37_RS17130 and TK37_RS17135 and TK37_RS06235 and TK37_RS04870 and TK37_RS06590 and TK37_RS08285 and TK37_RS11885",
+"gene_reaction_rule":"WP_014950103.1 and WP_039229319.1 and WP_014977618.1 and WP_014949255.1 and WP_015000154.1 and WP_039226687.1 and WP_014948265.1 and WP_049587775.1",
 "annotation":{
 "metanetx.reaction":"MNXR134851",
 "sbo":"SBO:0000176",
@@ -46958,7 +46958,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10990",
+"gene_reaction_rule":"WP_014949855.1",
 "annotation":{
 "ec-code":"2.7.1.40",
 "kegg.orthology":[
@@ -46984,7 +46984,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS20165",
+"gene_reaction_rule":"WP_049589179.1",
 "annotation":{
 "bigg.reaction":"PTHKr",
 "biocyc":"META:PANTETHEINE-KINASE-RXN",
@@ -47021,7 +47021,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02440",
+"gene_reaction_rule":"WP_014948475.1",
 "annotation":{
 "bigg.reaction":"NTPP10",
 "biocyc":"META:RXN0-1602",
@@ -47052,7 +47052,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS20290 and TK37_RS08330",
+"gene_reaction_rule":"WP_049589197.1 and WP_049587049.1",
 "annotation":{
 "bigg.reaction":"UDCPDP",
 "biocyc":"META:UNDECAPRENYL-DIPHOSPHATASE-RXN",
@@ -47086,7 +47086,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19705",
+"gene_reaction_rule":"WP_039217399.1",
 "annotation":{
 "bigg.reaction":[
 "GALK",
@@ -47114,7 +47114,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17750",
+"gene_reaction_rule":"WP_049588841.1",
 "annotation":{
 "biocyc":"META:ALLANTOATE-DEIMINASE-RXN",
 "ec-code":"3.5.3.9",
@@ -47142,7 +47142,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16075",
+"gene_reaction_rule":"WP_049588635.1",
 "annotation":{
 "bigg.reaction":"ADK2",
 "metanetx.reaction":"MNXR95451",
@@ -47162,7 +47162,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS10875 and TK37_RS08230 and TK37_RS09355 and TK37_RS20075 and TK37_RS17090 and TK37_RS04250 and TK37_RS08845 and TK37_RS18115 and TK37_RS09010) or TK37_RS18115",
+"gene_reaction_rule":"(WP_014947786.1 and WP_049587019.1 and WP_049587262.1 and WP_049589161.1 and WP_014949232.1 and WP_039227752.1 and WP_049587138.1 and WP_014976690.1 and WP_049587170.1) or WP_014976690.1",
 "annotation":{
 "bigg.reaction":"ACOAD7f",
 "ec-code":[
@@ -47197,7 +47197,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12790",
+"gene_reaction_rule":"WP_049588021.1",
 "annotation":{
 "biocyc":"META:RXN-14228",
 "ec-code":"2.7.4.6",
@@ -47224,7 +47224,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07910",
+"gene_reaction_rule":"WP_049586958.1",
 "annotation":{
 "bigg.reaction":[
 "EAR60x",
@@ -47255,7 +47255,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07765",
+"gene_reaction_rule":"WP_014950772.1",
 "annotation":{
 "bigg.reaction":[
 "FUR4",
@@ -47286,7 +47286,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14420",
+"gene_reaction_rule":"WP_049588345.1",
 "annotation":{
 "bigg.reaction":[
 "AIRC2r",
@@ -47318,7 +47318,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17600 and TK37_RS14480",
+"gene_reaction_rule":"WP_014950684.1 and WP_049588355.1",
 "annotation":{
 "bigg.reaction":"ALDD22x",
 "biocyc":[
@@ -47358,7 +47358,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03330",
+"gene_reaction_rule":"WP_049586053.1",
 "annotation":{
 "bigg.reaction":"UGMDDS",
 "biocyc":"META:UDP-NACMURALGLDAPAALIG-RXN",
@@ -47393,7 +47393,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08230 or (TK37_RS10875 and TK37_RS08230 and TK37_RS09355 and TK37_RS20075 and TK37_RS17090 and TK37_RS04250 and TK37_RS08845 and TK37_RS18115 and TK37_RS09010) or TK37_RS18115",
+"gene_reaction_rule":"WP_049587019.1 or (WP_014947786.1 and WP_049587019.1 and WP_049587262.1 and WP_049589161.1 and WP_014949232.1 and WP_039227752.1 and WP_049587138.1 and WP_014976690.1 and WP_049587170.1) or WP_014976690.1",
 "annotation":{
 "bigg.reaction":"ACOAD2f",
 "ec-code":[
@@ -47430,7 +47430,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03165",
+"gene_reaction_rule":"WP_049586037.1",
 "annotation":{
 "bigg.reaction":[
 "PRO1x",
@@ -47463,7 +47463,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1A161pp",
 "ec-code":"3.1.1.5",
@@ -47483,7 +47483,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12610 and TK37_RS15400 and TK37_RS03220 and TK37_RS19185 and TK37_RS01765",
+"gene_reaction_rule":"WP_049587995.1 and WP_049588550.1 and WP_049586043.1 and WP_014949867.1 and WP_049585855.1",
 "annotation":{
 "biocyc":"META:4-NITROPHENYLPHOSPHATASE-RXN",
 "ec-code":[
@@ -47516,7 +47516,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09215",
+"gene_reaction_rule":"WP_049587223.1",
 "annotation":{
 "biocyc":"META:1.5.1.9-RXN",
 "ec-code":"1.5.1.9",
@@ -47539,7 +47539,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16615",
+"gene_reaction_rule":"WP_014976407.1",
 "annotation":{
 "bigg.reaction":[
 "ASP31",
@@ -47584,7 +47584,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15995",
+"gene_reaction_rule":"WP_014949444.1",
 "annotation":{
 "bigg.reaction":[
 "CS",
@@ -47632,7 +47632,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04530",
+"gene_reaction_rule":"WP_049586293.1",
 "annotation":{
 "bigg.reaction":[
 "DH or D2",
@@ -47663,7 +47663,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18125",
+"gene_reaction_rule":"WP_014979424.1",
 "annotation":{
 "bigg.reaction":[
 "ADE8",
@@ -47696,7 +47696,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14210",
+"gene_reaction_rule":"WP_014948076.1",
 "annotation":{
 "ec-code":"4.1.1.65",
 "metanetx.reaction":"MNXR136228",
@@ -47718,7 +47718,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05860",
+"gene_reaction_rule":"WP_014950116.1",
 "annotation":{
 "bigg.reaction":[
 "NADS1m",
@@ -47754,7 +47754,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18845",
+"gene_reaction_rule":"WP_049588978.1",
 "annotation":{
 "bigg.reaction":"MLTP2",
 "biocyc":"META:RXN-14285",
@@ -47777,7 +47777,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17000 and TK37_RS02810",
+"gene_reaction_rule":"WP_012518211.1 and WP_015066413.1",
 "annotation":{
 "bigg.reaction":"UAGAAT",
 "biocyc":"META:UDPNACETYLGLUCOSAMACYLTRANS-RXN",
@@ -47803,7 +47803,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560 or TK37_RS02805",
+"gene_reaction_rule":"WP_014949559.1 or WP_014948562.1",
 "annotation":{
 "bigg.reaction":"3HAD141",
 "ec-code":"4.2.1.61",
@@ -47826,7 +47826,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06150",
+"gene_reaction_rule":"WP_049586628.1",
 "annotation":{
 "bigg.reaction":[
 "VALabcpp",
@@ -47852,7 +47852,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18685 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715 and TK37_RS11765 and TK37_RS01845",
+"gene_reaction_rule":"WP_049588954.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1 and WP_014976911.1 and WP_014948837.1",
 "annotation":{
 "bigg.reaction":"ECOAH1",
 "biocyc":[
@@ -47895,7 +47895,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12355 and TK37_RS17565",
+"gene_reaction_rule":"WP_049587909.1 and WP_049588809.1",
 "annotation":{
 "bigg.reaction":[
 "AAH1_2",
@@ -47924,7 +47924,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15170 or TK37_RS15170",
+"gene_reaction_rule":"WP_049588490.1 or WP_049588490.1",
 "annotation":{
 "bigg.reaction":"RMPA",
 "biocyc":"META:RHAMNULPALDOL-RXN",
@@ -47949,7 +47949,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS08895 and TK37_RS11755) or (TK37_RS09780 and TK37_RS13445 and TK37_RS18295 and TK37_RS07135 and TK37_RS17935)",
+"gene_reaction_rule":"(WP_049587147.1 and WP_049587746.1) or (WP_049587342.1 and WP_014977336.1 and WP_049588907.1 and WP_049586860.1 and WP_049588854.1)",
 "annotation":{
 "bigg.reaction":"CHOLD",
 "biocyc":"META:RXN-6021",
@@ -47977,7 +47977,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04710",
+"gene_reaction_rule":"WP_080986386.1",
 "annotation":{
 "ec-code":"2.7.8.12",
 "metanetx.reaction":"MNXR136285",
@@ -47996,7 +47996,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17275",
+"gene_reaction_rule":"WP_039229281.1",
 "annotation":{
 "bigg.reaction":"AMID4",
 "biocyc":"META:RXN-14728",
@@ -48019,7 +48019,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00590",
+"gene_reaction_rule":"WP_049585748.1",
 "annotation":{
 "bigg.reaction":"OCDCAt2",
 "metanetx.reaction":"MNXR102142",
@@ -48040,7 +48040,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02185",
+"gene_reaction_rule":"WP_049585903.1",
 "annotation":{
 "bigg.reaction":[
 "AOXSr",
@@ -48074,7 +48074,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01140 and TK37_RS09770",
+"gene_reaction_rule":"WP_049585722.1 and WP_049587341.1",
 "annotation":{
 "biocyc":"META:RXN-11632",
 "ec-code":"1.5.1.12",
@@ -48106,7 +48106,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17000",
+"gene_reaction_rule":"WP_012518211.1",
 "annotation":{
 "bigg.reaction":"AACPS8",
 "ec-code":"6.2.1.20",
@@ -48124,7 +48124,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16730",
+"gene_reaction_rule":"WP_014949367.1",
 "annotation":{
 "bigg.reaction":"PGAMT",
 "biocyc":"META:5.4.2.10-RXN",
@@ -48152,7 +48152,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06025",
+"gene_reaction_rule":"WP_049586604.1",
 "annotation":{
 "bigg.reaction":[
 "PGPP160pp",
@@ -48173,7 +48173,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07485 and TK37_RS06190 and TK37_RS17240 and TK37_RS18625 and TK37_RS17790",
+"gene_reaction_rule":"WP_014949914.1 and WP_049586645.1 and WP_049588766.1 and WP_049588948.1 and WP_049588845.1",
 "annotation":{
 "bigg.reaction":"Ktex",
 "biocyc":[
@@ -48200,7 +48200,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02740",
+"gene_reaction_rule":"WP_014948549.1",
 "annotation":{
 "bigg.reaction":"THDPS",
 "biocyc":"META:TETHYDPICSUCC-RXN",
@@ -48228,7 +48228,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06155",
+"gene_reaction_rule":"WP_049586630.1",
 "annotation":{
 "bigg.reaction":"PSSA141",
 "ec-code":"2.7.8.8",
@@ -48248,7 +48248,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16225",
+"gene_reaction_rule":"WP_014949662.1",
 "annotation":{
 "bigg.reaction":[
 "THIORDXm",
@@ -48275,7 +48275,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08840",
+"gene_reaction_rule":"WP_039236747.1",
 "annotation":{
 "bigg.reaction":[
 "GK1",
@@ -48303,7 +48303,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15970",
+"gene_reaction_rule":"WP_049588626.1",
 "annotation":{
 "ec-code":"1.2.4.2",
 "kegg.orthology":[
@@ -48326,7 +48326,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17260 or TK37_RS00735",
+"gene_reaction_rule":"WP_014951061.1 or WP_049585624.1",
 "annotation":{
 "ec-code":"3.5.4.16",
 "kegg.orthology":[
@@ -48350,7 +48350,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18685 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715 and TK37_RS11765 and TK37_RS01845",
+"gene_reaction_rule":"WP_049588954.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1 and WP_014976911.1 and WP_014948837.1",
 "annotation":{
 "bigg.reaction":"ECOAH2",
 "biocyc":"META:RXN-12567",
@@ -48388,7 +48388,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14325",
+"gene_reaction_rule":"WP_049588327.1",
 "annotation":{
 "bigg.reaction":[
 "AGPR",
@@ -48418,7 +48418,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17275",
+"gene_reaction_rule":"WP_039229281.1",
 "annotation":{
 "bigg.reaction":[
 "AMID3",
@@ -48451,7 +48451,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19680",
+"gene_reaction_rule":"WP_049589075.1",
 "annotation":{
 "bigg.reaction":[
 "MELTGH",
@@ -48481,7 +48481,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05740 and TK37_RS07435",
+"gene_reaction_rule":"WP_014979808.1 and WP_049586877.1",
 "annotation":{
 "biocyc":"META:LIPIDXSYNTHESIS-RXN",
 "ec-code":"3.6.1.54",
@@ -48513,7 +48513,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18950",
+"gene_reaction_rule":"WP_049588997.1",
 "annotation":{
 "bigg.reaction":[
 "YIL145C",
@@ -48551,7 +48551,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09780 and TK37_RS13445 and TK37_RS18295 and TK37_RS07135 and TK37_RS17935",
+"gene_reaction_rule":"WP_049587342.1 and WP_014977336.1 and WP_049588907.1 and WP_049586860.1 and WP_049588854.1",
 "annotation":{
 "bigg.reaction":"ALCD2z",
 "biocyc":[
@@ -48586,7 +48586,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01140 or (TK37_RS01140 and TK37_RS09770)",
+"gene_reaction_rule":"WP_049585722.1 or (WP_049585722.1 and WP_049587341.1)",
 "annotation":{
 "bigg.reaction":[
 "GSADH",
@@ -48624,7 +48624,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16450 and TK37_RS16455",
+"gene_reaction_rule":"WP_039227383.1 and WP_014950719.1",
 "annotation":{
 "bigg.reaction":[
 "ECM17",
@@ -48666,7 +48666,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06025",
+"gene_reaction_rule":"WP_049586604.1",
 "annotation":{
 "bigg.reaction":[
 "PGPP181pp",
@@ -48689,7 +48689,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02630",
+"gene_reaction_rule":"WP_014948529.1",
 "annotation":{
 "ec-code":"2.7.8.-",
 "metanetx.reaction":"MNXR136304",
@@ -48709,7 +48709,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00345",
+"gene_reaction_rule":"WP_049585746.1",
 "annotation":{
 "ec-code":"1.8.1.8",
 "kegg.reaction":"R03914",
@@ -48730,7 +48730,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18640 and TK37_RS13800",
+"gene_reaction_rule":"WP_014949721.1 and WP_049588230.1",
 "annotation":{
 "biocyc":"META:RXN-11737",
 "ec-code":"2.6.1.1",
@@ -48757,7 +48757,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12220",
+"gene_reaction_rule":"WP_049587867.1",
 "annotation":{
 "bigg.reaction":[
 "SEC53",
@@ -48793,7 +48793,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13895",
+"gene_reaction_rule":"WP_049588244.1",
 "annotation":{
 "bigg.reaction":[
 "CYSTLr",
@@ -48819,7 +48819,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09460 and TK37_RS09455",
+"gene_reaction_rule":"WP_049587283.1 and WP_049587281.1",
 "annotation":{
 "bigg.reaction":[
 "DUR1_2",
@@ -48853,7 +48853,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07235",
+"gene_reaction_rule":"WP_049586834.1",
 "annotation":{
 "biocyc":"META:IGPSYN-RXN",
 "ec-code":"4.1.1.48",
@@ -48885,7 +48885,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06025",
+"gene_reaction_rule":"WP_049586604.1",
 "annotation":{
 "ec-code":"3.1.3.27",
 "metanetx.reaction":"MNXR136264",
@@ -48905,7 +48905,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01135 and TK37_RS14160 and TK37_RS14165",
+"gene_reaction_rule":"WP_014951084.1 and WP_014975513.1 and WP_049588309.1",
 "annotation":{
 "bigg.reaction":[
 "ACHBS",
@@ -48942,7 +48942,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17270",
+"gene_reaction_rule":"WP_049588770.1",
 "annotation":{
 "bigg.reaction":"AGMTNDMN",
 "biocyc":"META:AGMATINE-DEIMINASE-RXN",
@@ -48967,7 +48967,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02780",
+"gene_reaction_rule":"WP_014948557.1",
 "annotation":{
 "ec-code":"2.7.7.41",
 "metanetx.reaction":"MNXR136216",
@@ -48986,7 +48986,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13780",
+"gene_reaction_rule":"WP_049588224.1",
 "annotation":{
 "ec-code":"2.7.8.5",
 "metanetx.reaction":"MNXR136257",
@@ -49005,7 +49005,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03445 or (TK37_RS01080 and TK37_RS13150)",
+"gene_reaction_rule":"WP_049586083.1 or (WP_049585701.1 and WP_049588105.1)",
 "annotation":{
 "bigg.reaction":[
 "AGM4PA",
@@ -49028,7 +49028,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02775",
+"gene_reaction_rule":"WP_080986374.1",
 "annotation":{
 "ec-code":[
 "2.5.1.31",
@@ -49052,7 +49052,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07240 and TK37_RS07245",
+"gene_reaction_rule":"WP_049586836.1 and WP_049586837.1",
 "annotation":{
 "bigg.reaction":"TRPS1r",
 "biocyc":"META:TRYPSYN-RXN",
@@ -49085,7 +49085,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1G181pp",
 "ec-code":"3.1.1.5",
@@ -49105,7 +49105,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10685",
+"gene_reaction_rule":"WP_049587528.1",
 "annotation":{
 "bigg.reaction":[
 "PPCDC",
@@ -49143,7 +49143,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12355 and TK37_RS17565",
+"gene_reaction_rule":"WP_049587909.1 and WP_049588809.1",
 "annotation":{
 "bigg.reaction":[
 "ADA",
@@ -49175,7 +49175,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15550",
+"gene_reaction_rule":"WP_049588567.1",
 "annotation":{
 "bigg.reaction":"MOAT",
 "biocyc":"META:KDOTRANS-RXN",
@@ -49203,7 +49203,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04315",
+"gene_reaction_rule":"WP_049586246.1",
 "annotation":{
 "bigg.reaction":[
 "PFK1_3",
@@ -49227,7 +49227,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15165",
+"gene_reaction_rule":"WP_049588489.1",
 "annotation":{
 "bigg.reaction":[
 "LLXI",
@@ -49250,7 +49250,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19140",
+"gene_reaction_rule":"WP_049589017.1",
 "annotation":{
 "bigg.reaction":"GUI1",
 "ec-code":"5.3.1.12",
@@ -49275,7 +49275,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10360 and TK37_RS13625",
+"gene_reaction_rule":"WP_015066029.1 and WP_014976618.1",
 "annotation":{
 "ec-code":"2.7.1.107",
 "metanetx.reaction":"MNXR136251",
@@ -49295,7 +49295,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL1A140pp",
 "ec-code":"3.1.1.5",
@@ -49314,7 +49314,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11450 or TK37_RS11450",
+"gene_reaction_rule":"WP_049587680.1 or WP_049587680.1",
 "annotation":{
 "bigg.reaction":[
 "YJR078W",
@@ -49349,7 +49349,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13780",
+"gene_reaction_rule":"WP_049588224.1",
 "annotation":{
 "bigg.reaction":"PGSA120",
 "ec-code":"2.7.8.5",
@@ -49369,7 +49369,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01120",
+"gene_reaction_rule":"WP_049585717.1",
 "annotation":{
 "bigg.reaction":[
 "FCLT",
@@ -49406,7 +49406,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17020",
+"gene_reaction_rule":"WP_049588748.1",
 "annotation":{
 "bigg.reaction":[
 "CDC8",
@@ -49442,7 +49442,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560 or TK37_RS02805",
+"gene_reaction_rule":"WP_014949559.1 or WP_014948562.1",
 "annotation":{
 "bigg.reaction":[
 "3HAD100",
@@ -49476,7 +49476,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05595 or (TK37_RS15255 and TK37_RS01710 and TK37_RS17085)",
+"gene_reaction_rule":"WP_049586525.1 or (WP_024015658.1 and WP_049585851.1 and WP_049588755.1)",
 "annotation":{
 "bigg.reaction":[
 "ACACT6p",
@@ -49510,7 +49510,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14860 or TK37_RS14860",
+"gene_reaction_rule":"WP_014951396.1 or WP_014951396.1",
 "annotation":{
 "ec-code":"1.1.1.86",
 "kegg.orthology":"K00053",
@@ -49532,7 +49532,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02780",
+"gene_reaction_rule":"WP_014948557.1",
 "annotation":{
 "bigg.reaction":"DASYN140",
 "ec-code":"2.7.7.41",
@@ -49552,7 +49552,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05940 and TK37_RS17035",
+"gene_reaction_rule":"WP_014950101.1 and WP_039229648.1",
 "annotation":{
 "bigg.reaction":[
 "PDX5POi",
@@ -49587,7 +49587,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07475",
+"gene_reaction_rule":"WP_039225290.1",
 "annotation":{
 "bigg.reaction":[
 "GLYOX",
@@ -49618,7 +49618,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05995",
+"gene_reaction_rule":"WP_080986394.1",
 "annotation":{
 "bigg.reaction":[
 "APRAUR",
@@ -49652,7 +49652,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16705 and TK37_RS17080 and TK37_RS15260 and TK37_RS01715",
+"gene_reaction_rule":"WP_049588707.1 and WP_049588754.1 and WP_049588521.1 and WP_049585918.1",
 "annotation":{
 "bigg.reaction":[
 "HACD3",
@@ -49689,7 +49689,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14645 and TK37_RS00650",
+"gene_reaction_rule":"WP_049588396.1 and WP_049585600.1",
 "annotation":{
 "bigg.reaction":[
 "PCAD",
@@ -49723,7 +49723,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11000",
+"gene_reaction_rule":"WP_049587589.1",
 "annotation":{
 "bigg.reaction":[
 "G6PDH2",
@@ -49757,7 +49757,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02750 or (TK37_RS13980 and TK37_RS20685) or (TK37_RS04495 and TK37_RS07675) or TK37_RS05630 or TK37_RS18985 or TK37_RS05630",
+"gene_reaction_rule":"WP_049585982.1 or (WP_014999437.1 and WP_053103828.1) or (WP_049586284.1 and WP_080986400.1) or WP_049586533.1 or WP_049589000.1 or WP_049586533.1",
 "annotation":{
 "bigg.reaction":"MEAMP1(gly-asn)",
 "metanetx.reaction":"MNXR137145",
@@ -49776,7 +49776,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10760",
+"gene_reaction_rule":"WP_014977894.1",
 "annotation":{
 "bigg.reaction":[
 "GLYATi",
@@ -49804,7 +49804,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02630",
+"gene_reaction_rule":"WP_014948529.1",
 "annotation":{
 "ec-code":"2.7.8.-",
 "metanetx.reaction":"MNXR136308",
@@ -49826,7 +49826,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07060",
+"gene_reaction_rule":"WP_049586790.1",
 "annotation":{
 "bigg.reaction":"ACS2",
 "biocyc":"META:PROPIONATE--COA-LIGASE-RXN",
@@ -49857,7 +49857,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13275 and TK37_RS04100",
+"gene_reaction_rule":"WP_053103824.1 and WP_014948398.1",
 "annotation":{
 "bigg.reaction":[
 "PPK2",
@@ -49882,7 +49882,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07955",
+"gene_reaction_rule":"WP_014950808.1",
 "annotation":{
 "bigg.reaction":"URIK3",
 "ec-code":"2.7.1.48",
@@ -49904,7 +49904,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14335",
+"gene_reaction_rule":"WP_014948051.1",
 "annotation":{
 "biocyc":[
 "META:ORNCARBAMTRANSFER-RXN",
@@ -49933,7 +49933,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04430",
+"gene_reaction_rule":"WP_049586270.1",
 "annotation":{
 "ec-code":"2.3.1.168",
 "kegg.orthology":"K09699",
@@ -49958,7 +49958,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01790 and TK37_RS03265) or TK37_RS14285",
+"gene_reaction_rule":"(WP_049585859.1 and WP_039227930.1) or WP_039231048.1",
 "annotation":{
 "bigg.reaction":"LPLIPAL2G161",
 "ec-code":"3.1.1.5",
@@ -49980,7 +49980,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08435 and TK37_RS11220 and TK37_RS11660 and TK37_RS03755 and TK37_RS18545",
+"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
 "annotation":{
 "bigg.reaction":"FACOAL181",
 "metanetx.reaction":"MNXR136033",
@@ -50000,7 +50000,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01855",
+"gene_reaction_rule":"WP_014976023.1",
 "annotation":{
 "biocyc":"META:CYCLOHEXADIENYL-DEHYDROGENASE-RXN",
 "ec-code":[
@@ -50030,7 +50030,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06155",
+"gene_reaction_rule":"WP_049586630.1",
 "annotation":{
 "bigg.reaction":"PSSA160",
 "ec-code":"2.7.8.8",
@@ -50051,7 +50051,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03720",
+"gene_reaction_rule":"WP_049586139.1",
 "annotation":{
 "bigg.reaction":"NTPP7",
 "biocyc":[
@@ -50079,7 +50079,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10360 and TK37_RS13625",
+"gene_reaction_rule":"WP_015066029.1 and WP_014976618.1",
 "annotation":{
 "bigg.reaction":"DAGK140",
 "ec-code":"2.7.1.107",
@@ -50099,7 +50099,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16310",
+"gene_reaction_rule":"WP_049588665.1",
 "annotation":{
 "bigg.reaction":[
 "PSERTr",
@@ -50130,7 +50130,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS20115",
+"gene_reaction_rule":"WP_049589172.1",
 "annotation":{
 "bigg.reaction":[
 "DHFS",
@@ -50170,7 +50170,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15730",
+"gene_reaction_rule":"WP_049588586.1",
 "annotation":{
 "bigg.reaction":"4OT",
 "ec-code":[
@@ -50196,7 +50196,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17070",
+"gene_reaction_rule":"WP_014949228.1",
 "annotation":{
 "biocyc":"META:GLUCOSE-1-DEHYDROGENASE-NADP+-RXN",
 "ec-code":[
@@ -50229,7 +50229,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS17265 and TK37_RS17800) or TK37_RS09840",
+"gene_reaction_rule":"(WP_049588769.1 and WP_049588847.1) or WP_039231980.1",
 "annotation":{
 "bigg.reaction":[
 "DFR1_2",
@@ -50275,7 +50275,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13780",
+"gene_reaction_rule":"WP_049588224.1",
 "annotation":{
 "bigg.reaction":"PGSA161",
 "ec-code":"2.7.8.5",
@@ -50296,7 +50296,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14245",
+"gene_reaction_rule":"WP_014948069.1",
 "annotation":{
 "bigg.reaction":"RNDR2b",
 "metanetx.reaction":"MNXR104063",
@@ -50316,7 +50316,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16295 and TK37_RS16290",
+"gene_reaction_rule":"WP_014949648.1 and WP_014949649.1",
 "annotation":{
 "bigg.reaction":[
 "RNDR4n",
@@ -50354,7 +50354,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS20115",
+"gene_reaction_rule":"WP_049589172.1",
 "annotation":{
 "bigg.reaction":[
 "RMA1",
@@ -50385,7 +50385,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11035",
+"gene_reaction_rule":"WP_049587596.1",
 "annotation":{
 "bigg.reaction":"AMALT4",
 "ec-code":"2.4.1.25",
@@ -50407,7 +50407,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17600 and TK37_RS14480",
+"gene_reaction_rule":"WP_014950684.1 and WP_049588355.1",
 "annotation":{
 "bigg.reaction":[
 "ALDD8x",
@@ -50446,7 +50446,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18050 and TK37_RS16575",
+"gene_reaction_rule":"WP_039227619.1 and WP_014949336.1",
 "annotation":{
 "bigg.reaction":[
 "TRDRm",
@@ -50475,7 +50475,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS18800 and TK37_RS05730) or (TK37_RS18800 and TK37_RS05730)",
+"gene_reaction_rule":"(WP_049588971.1 and WP_049586563.1) or (WP_049588971.1 and WP_049586563.1)",
 "annotation":{
 "bigg.reaction":"SDPDS",
 "biocyc":"META:SUCCDIAMINOPIMDESUCC-RXN",
@@ -50499,7 +50499,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12790",
+"gene_reaction_rule":"WP_049588021.1",
 "annotation":{
 "bigg.reaction":[
 "YNK1_1",
@@ -50537,7 +50537,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16985 or TK37_RS11900 or TK37_RS17005",
+"gene_reaction_rule":"WP_014949212.1 or WP_014949953.1 or WP_049588746.1",
 "annotation":{
 "bigg.reaction":[
 "MCMAT4",
@@ -50574,7 +50574,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09700",
+"gene_reaction_rule":"WP_014948183.1",
 "annotation":{
 "bigg.reaction":[
 "TMDS",
@@ -50611,7 +50611,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS01150 and TK37_RS16300) or (TK37_RS01150 and TK37_RS16300)",
+"gene_reaction_rule":"(WP_049585726.1 and WP_014949647.1) or (WP_049585726.1 and WP_014949647.1)",
 "annotation":{
 "bigg.reaction":"OHPHM",
 "biocyc":"META:2-OCTAPRENYL-6-OHPHENOL-METHY-RXN",
@@ -50640,7 +50640,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12590",
+"gene_reaction_rule":"WP_049587987.1",
 "annotation":{
 "bigg.reaction":[
 "MLS1",
@@ -50678,7 +50678,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08435 and TK37_RS11220 and TK37_RS11660 and TK37_RS03755 and TK37_RS18545",
+"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
 "annotation":{
 "bigg.reaction":[
 "FACOAL140",
@@ -50703,7 +50703,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16310",
+"gene_reaction_rule":"WP_049588665.1",
 "annotation":{
 "bigg.reaction":[
 "OHPBAT",
@@ -50730,7 +50730,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03655",
+"gene_reaction_rule":"WP_049586129.1",
 "annotation":{
 "ec-code":"1.1.1.262",
 "kegg.orthology":"K00097",
@@ -50752,7 +50752,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03535",
+"gene_reaction_rule":"WP_014977204.1",
 "annotation":{
 "bigg.reaction":[
 "GNNUC",
@@ -50785,7 +50785,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(TK37_RS18640 and TK37_RS13800) or TK37_RS16140",
+"gene_reaction_rule":"(WP_014949721.1 and WP_049588230.1) or WP_049588647.1",
 "annotation":{
 "bigg.reaction":[
 "ARO9_1",
@@ -50837,7 +50837,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10360 and TK37_RS13625",
+"gene_reaction_rule":"WP_015066029.1 and WP_014976618.1",
 "annotation":{
 "bigg.reaction":"DAGK161",
 "ec-code":"2.7.1.107",
@@ -50856,7 +50856,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01510 and TK37_RS11860 and TK37_RS12270",
+"gene_reaction_rule":"WP_080760014.1 and WP_049587770.1 and WP_014950300.1",
 "annotation":{
 "bigg.reaction":[
 "GLO1",
@@ -50883,7 +50883,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00545",
+"gene_reaction_rule":"WP_049585574.1",
 "annotation":{
 "bigg.reaction":[
 "UAGDP",
@@ -50924,7 +50924,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01435",
+"gene_reaction_rule":"WP_049585822.1",
 "annotation":{
 "bigg.reaction":[
 "YGL186C_2",
@@ -50956,7 +50956,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19710",
+"gene_reaction_rule":"WP_049589081.1",
 "annotation":{
 "bigg.reaction":[
 "GAL7_2",
@@ -50986,7 +50986,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03720",
+"gene_reaction_rule":"WP_049586139.1",
 "annotation":{
 "bigg.reaction":"NTPP4",
 "biocyc":[
@@ -51027,7 +51027,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02775",
+"gene_reaction_rule":"WP_080986374.1",
 "annotation":{
 "ec-code":[
 "2.5.1.31",
@@ -51050,7 +51050,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12790",
+"gene_reaction_rule":"WP_049588021.1",
 "annotation":{
 "bigg.reaction":[
 "NDPK8",
@@ -51083,7 +51083,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19680",
+"gene_reaction_rule":"WP_049589075.1",
 "annotation":{
 "ec-code":"3.2.1.22",
 "kegg.orthology":[
@@ -51112,7 +51112,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16995",
+"gene_reaction_rule":"WP_014976326.1",
 "annotation":{
 "biocyc":"META:RXN-11476",
 "ec-code":"1.1.1.100",
@@ -51132,7 +51132,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15010",
+"gene_reaction_rule":"WP_014977794.1",
 "annotation":{
 "biocyc":"META:RXN-11483",
 "ec-code":"3.1.1.85",
@@ -51164,7 +51164,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16050",
+"gene_reaction_rule":"WP_049588633.1",
 "annotation":{
 "ec-code":"1.18.1.2",
 "kegg.reaction":"R01195",
@@ -51185,7 +51185,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09295",
+"gene_reaction_rule":"WP_049587244.1",
 "annotation":{
 "biocyc":"META:RXN-17809",
 "ec-code":"4.6.1.17",
@@ -51213,7 +51213,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12770 and TK37_RS10915 and TK37_RS10910 and TK37_RS10920",
+"gene_reaction_rule":"WP_049588019.1 and WP_049587566.1 and WP_049587565.1 and WP_049587568.1",
 "annotation":{
 "biocyc":"META:THIAZOLSYN2-RXN",
 "ec-code":[
@@ -51235,7 +51235,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04560 or TK37_RS04560",
+"gene_reaction_rule":"WP_014949559.1 or WP_014949559.1",
 "annotation":{
 "ec-code":"5.3.3.14",
 "kegg.orthology":[
@@ -51259,7 +51259,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18055",
+"gene_reaction_rule":"WP_049588867.1",
 "annotation":{
 "biocyc":"META:RXN0-6254",
 "ec-code":"2.7.7.76",
@@ -51282,7 +51282,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11900 or TK37_RS17005",
+"gene_reaction_rule":"WP_014949953.1 or WP_049588746.1",
 "annotation":{
 "biocyc":"META:RXN-11474",
 "sbo":"SBO:0000176",
@@ -51301,7 +51301,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16995",
+"gene_reaction_rule":"WP_014976326.1",
 "annotation":{
 "biocyc":"META:RXN-11480",
 "ec-code":"1.1.1.100",
@@ -51323,7 +51323,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10925",
+"gene_reaction_rule":"WP_049587570.1",
 "annotation":{
 "biocyc":"META:RXN-12610",
 "ec-code":"2.5.1.3",
@@ -51355,7 +51355,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01135 and TK37_RS14160 and TK37_RS14165",
+"gene_reaction_rule":"WP_014951084.1 and WP_014975513.1 and WP_049588309.1",
 "annotation":{
 "bigg.reaction":[
 "ACLSm",
@@ -51390,7 +51390,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13255 and TK37_RS18655",
+"gene_reaction_rule":"WP_049588124.1 and WP_041693510.1",
 "annotation":{
 "bigg.reaction":"SHSL1",
 "biocyc":"META:O-SUCCHOMOSERLYASE-RXN",
@@ -51421,7 +51421,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14860 or TK37_RS14860",
+"gene_reaction_rule":"WP_014951396.1 or WP_014951396.1",
 "annotation":{
 "bigg.reaction":[
 "KARA1",
@@ -51447,7 +51447,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14945",
+"gene_reaction_rule":"WP_049588465.1",
 "annotation":{
 "kegg.orthology":"K02259",
 "kegg.reaction":"R07412",
@@ -51470,7 +51470,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15790 and TK37_RS15775 and TK37_RS15785 and TK37_RS15800 and TK37_RS15780 and TK37_RS15795",
+"gene_reaction_rule":"WP_049588597.1 and WP_049588594.1 and WP_049588596.1 and WP_049588599.1 and WP_049588595.1 and WP_049588598.1",
 "annotation":{
 "kegg.orthology":[
 "K16246",
@@ -51500,7 +51500,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15790 and TK37_RS15775 and TK37_RS15785 and TK37_RS15800 and TK37_RS15780 and TK37_RS15795",
+"gene_reaction_rule":"WP_049588597.1 and WP_049588594.1 and WP_049588596.1 and WP_049588599.1 and WP_049588595.1 and WP_049588598.1",
 "annotation":{
 "biocyc":"META:RXN-17503",
 "ec-code":"1.14.13.M20",
@@ -51535,7 +51535,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08145",
+"gene_reaction_rule":"WP_049586998.1",
 "annotation":{
 "metanetx.reaction":"MNXR137933",
 "sbo":"SBO:0000185",
@@ -51555,7 +51555,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00395 and TK37_RS00410 and TK37_RS00405 and TK37_RS00400",
+"gene_reaction_rule":"WP_049585518.1 and WP_012520077.1 and WP_049585522.1 and WP_049585520.1",
 "annotation":{
 "metanetx.reaction":"MNXR137928",
 "sbo":"SBO:0000655",
@@ -51575,7 +51575,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00790 and TK37_RS00795 and TK37_RS06765 and TK37_RS06770",
+"gene_reaction_rule":"WP_049585639.1 and WP_049585641.1 and WP_049586745.1 and WP_049586746.1",
 "annotation":{
 "metanetx.reaction":"MNXR137925",
 "sbo":"SBO:0000655",
@@ -51595,7 +51595,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13675 and TK37_RS13665 and TK37_RS13670 and TK37_RS13695 and TK37_RS09640 and TK37_RS13680 and TK37_RS13690 and TK37_RS08215",
+"gene_reaction_rule":"WP_014949591.1 and WP_049588214.1 and WP_014979357.1 and WP_014949594.1 and WP_049587321.1 and WP_039220102.1 and WP_049588217.1 and WP_049587017.1",
 "annotation":{
 "metanetx.reaction":"MNXR137932",
 "sbo":"SBO:0000655",
@@ -51616,7 +51616,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13185 and TK37_RS02210",
+"gene_reaction_rule":"WP_049588138.1 and WP_049585906.1",
 "annotation":{
 "bigg.reaction":"ADOCBLabcpp",
 "biocyc":"META:3.6.3.33-RXN",
@@ -51640,7 +51640,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12305",
+"gene_reaction_rule":"WP_049587892.1",
 "annotation":{
 "bigg.reaction":"ALAALAabcpp",
 "biocyc":"META:3.6.3.23-RXN",
@@ -51661,7 +51661,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17635 or TK37_RS10835",
+"gene_reaction_rule":"WP_049588823.1 or WP_049587551.1",
 "annotation":{
 "bigg.reaction":[
 "HNM1",
@@ -51688,7 +51688,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00505 and TK37_RS16420 and TK37_RS00500 and TK37_RS00495",
+"gene_reaction_rule":"WP_014951244.1 and WP_014950712.1 and WP_014951245.1 and WP_049585562.1",
 "annotation":{
 "bigg.reaction":[
 "THD2pp",
@@ -51714,7 +51714,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04950 and TK37_RS04965 and TK37_RS04955 and TK37_RS04960 and TK37_RS04930 and TK37_RS04945 and TK37_RS04935 and TK37_RS04940 and TK37_RS04925",
+"gene_reaction_rule":"WP_014951450.1 and WP_014951448.1 and WP_012520217.1 and WP_014951449.1 and WP_012520223.1 and WP_015000145.1 and WP_012520222.1 and WP_014951452.1 and WP_014977839.1",
 "annotation":{
 "bigg.reaction":[
 "ATPS4r",
@@ -51743,7 +51743,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10495 and TK37_RS00790 and TK37_RS10490 and TK37_RS06765",
+"gene_reaction_rule":"WP_012516857.1 and WP_049585639.1 and WP_049587488.1 and WP_049586745.1",
 "annotation":{
 "bigg.reaction":[
 "HYD1pp",
@@ -51768,7 +51768,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08145",
+"gene_reaction_rule":"WP_049586998.1",
 "annotation":{
 "bigg.reaction":[
 "NO3R2",
@@ -51791,7 +51791,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03825 and TK37_RS03820",
+"gene_reaction_rule":"WP_049586160.1 and WP_049586157.1",
 "annotation":{
 "metanetx.reaction":"MNXR137921",
 "sbo":"SBO:0000185",
@@ -51810,7 +51810,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00790 and TK37_RS00795 and TK37_RS06765 and TK37_RS06770",
+"gene_reaction_rule":"WP_049585639.1 and WP_049585641.1 and WP_049586745.1 and WP_049586746.1",
 "annotation":{
 "metanetx.reaction":"MNXR137924",
 "sbo":"SBO:0000185",
@@ -51829,7 +51829,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00395 and TK37_RS00410 and TK37_RS00405 and TK37_RS00400",
+"gene_reaction_rule":"WP_049585518.1 and WP_012520077.1 and WP_049585522.1 and WP_049585520.1",
 "annotation":{
 "metanetx.reaction":"MNXR137927",
 "sbo":"SBO:0000185",
@@ -51848,7 +51848,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13675 and TK37_RS13665 and TK37_RS13670 and TK37_RS13695 and TK37_RS09640 and TK37_RS13680 and TK37_RS13690 and TK37_RS08215",
+"gene_reaction_rule":"WP_014949591.1 and WP_049588214.1 and WP_014979357.1 and WP_014949594.1 and WP_049587321.1 and WP_039220102.1 and WP_049588217.1 and WP_049587017.1",
 "annotation":{
 "metanetx.reaction":"MNXR137931",
 "sbo":"SBO:0000185",
@@ -51867,7 +51867,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00790 and TK37_RS00795 and TK37_RS06765 and TK37_RS06770",
+"gene_reaction_rule":"WP_049585639.1 and WP_049585641.1 and WP_049586745.1 and WP_049586746.1",
 "annotation":{
 "metanetx.reaction":"MNXR137926",
 "sbo":"SBO:0000185",
@@ -51887,7 +51887,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08145",
+"gene_reaction_rule":"WP_049586998.1",
 "annotation":{
 "bigg.reaction":[
 "NO3R1",
@@ -51912,7 +51912,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10075 and TK37_RS14910 and TK37_RS14915 and TK37_RS10080 and TK37_RS14925",
+"gene_reaction_rule":"WP_049587404.1 and WP_080986445.1 and WP_039228778.1 and WP_049587406.1 and WP_014951383.1",
 "annotation":{
 "metanetx.reaction":"MNXR137923",
 "sbo":"SBO:0000655",
@@ -51928,7 +51928,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15225",
+"gene_reaction_rule":"WP_080986447.1",
 "annotation":{
 "biocyc":"META:RXN0-5306",
 "ec-code":[
@@ -51954,7 +51954,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09305",
+"gene_reaction_rule":"WP_049587246.1",
 "annotation":{
 "biocyc":"META:RXN-8342",
 "ec-code":"2.8.1.12",
@@ -51975,7 +51975,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09285",
+"gene_reaction_rule":"WP_049587243.1",
 "annotation":{
 "biocyc":"META:RXN-11361",
 "ec-code":"2.7.7.80",
@@ -51993,7 +51993,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02805",
+"gene_reaction_rule":"WP_014948562.1",
 "annotation":{
 "biocyc":"META:RXN-11481",
 "ec-code":"4.2.1.59",
@@ -52015,7 +52015,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18065",
+"gene_reaction_rule":"WP_049588869.1",
 "annotation":{
 "biocyc":"META:RXN-8348",
 "ec-code":"2.10.1.1",
@@ -52044,7 +52044,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19790",
+"gene_reaction_rule":"WP_049589095.1",
 "annotation":{
 "biocyc":"META:RXN-16456",
 "ec-code":"2.7.7.77",
@@ -52065,7 +52065,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10740",
+"gene_reaction_rule":"WP_014977890.1",
 "annotation":{
 "biocyc":"META:RXN-11328",
 "ec-code":"2.7.1.166",
@@ -52088,7 +52088,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19580",
+"gene_reaction_rule":"WP_049589071.1",
 "annotation":{
 "biocyc":"META:RXN-11564",
 "ec-code":[
@@ -52116,7 +52116,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15165",
+"gene_reaction_rule":"WP_049588489.1",
 "annotation":{
 "biocyc":"META:RHAMNISOM-RXN",
 "ec-code":"5.3.1.14",
@@ -52140,7 +52140,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15165",
+"gene_reaction_rule":"WP_049588489.1",
 "annotation":{
 "ec-code":"5.3.1.14",
 "kegg.orthology":[
@@ -52163,7 +52163,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02190",
+"gene_reaction_rule":"WP_049585904.1",
 "annotation":{
 "biocyc":"META:RXN-11475",
 "ec-code":"2.1.1.197",
@@ -52188,7 +52188,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02185",
+"gene_reaction_rule":"WP_049585903.1",
 "annotation":{
 "biocyc":"META:RXN-11484",
 "ec-code":"2.3.1.47",
@@ -52210,7 +52210,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02805",
+"gene_reaction_rule":"WP_014948562.1",
 "annotation":{
 "biocyc":"META:RXN-11477",
 "ec-code":"4.2.1.59",
@@ -52230,7 +52230,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08540",
+"gene_reaction_rule":"WP_014947858.1",
 "annotation":{
 "biocyc":"META:RXN-16937",
 "ec-code":"2.5.1.129",
@@ -52251,7 +52251,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02175",
+"gene_reaction_rule":"WP_049585925.1",
 "annotation":{
 "biocyc":"META:RXN-14930",
 "ec-code":"2.6.1.105",
@@ -52275,7 +52275,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09305",
+"gene_reaction_rule":"WP_049587246.1",
 "annotation":{
 "biocyc":"META:RXN-8342",
 "ec-code":"2.8.1.12",
@@ -52298,7 +52298,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10905",
+"gene_reaction_rule":"WP_049587563.1",
 "annotation":{
 "biocyc":"META:RXN-11319",
 "ec-code":"4.1.99.19",
@@ -52319,7 +52319,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17520",
+"gene_reaction_rule":"WP_049588802.1",
 "annotation":{
 "biocyc":"META:RXN-6201",
 "ec-code":"4.1.1.97",
@@ -52346,7 +52346,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19790",
+"gene_reaction_rule":"WP_049589095.1",
 "annotation":{
 "biocyc":"META:RXN0-262",
 "ec-code":"2.7.7.77",
@@ -52367,7 +52367,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19790",
+"gene_reaction_rule":"WP_049589095.1",
 "annotation":{
 "biocyc":"META:RXN-16457",
 "metanetx.reaction":"MNXR140619",
@@ -52387,7 +52387,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02680",
+"gene_reaction_rule":"WP_049585974.1",
 "annotation":{
 "biocyc":"META:RXN0-4022",
 "ec-code":"1.7.1.13",
@@ -52417,7 +52417,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07800",
+"gene_reaction_rule":"WP_049586947.1",
 "annotation":{
 "biocyc":"META:RXN0-6451",
 "ec-code":"3.5.1.110",
@@ -52440,7 +52440,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07800",
+"gene_reaction_rule":"WP_049586947.1",
 "annotation":{
 "biocyc":"META:RXN0-6460",
 "ec-code":[
@@ -52470,7 +52470,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07805",
+"gene_reaction_rule":"WP_049586948.1",
 "annotation":{
 "biocyc":"META:RXN0-6444",
 "ec-code":"1.14.99.46",
@@ -52500,7 +52500,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07790",
+"gene_reaction_rule":"WP_049586993.1",
 "annotation":{
 "biocyc":"META:RXN0-6452",
 "ec-code":"3.5.1.-",
@@ -52526,7 +52526,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03560",
+"gene_reaction_rule":"WP_049586104.1",
 "annotation":{
 "ec-code":"1.14.13.-",
 "kegg.reaction":"R04989",
@@ -52545,7 +52545,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11010",
+"gene_reaction_rule":"WP_014998717.1",
 "annotation":{
 "ec-code":"4.2.1.12",
 "kegg.orthology":"K01690",
@@ -52563,7 +52563,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19140",
+"gene_reaction_rule":"WP_049589017.1",
 "annotation":{
 "ec-code":"5.3.1.12",
 "kegg.orthology":"K01812",
@@ -52584,7 +52584,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19705",
+"gene_reaction_rule":"WP_039217399.1",
 "annotation":{
 "biocyc":"META:GALACTOKIN-RXN",
 "ec-code":"2.7.1.6",
@@ -52607,7 +52607,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09770",
+"gene_reaction_rule":"WP_049587341.1",
 "annotation":{
 "bigg.reaction":"PRO1q",
 "ec-code":"1.5.1.2",
@@ -52627,7 +52627,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10835",
+"gene_reaction_rule":"WP_049587551.1",
 "annotation":{
 "bigg.reaction":"CRNt2rpp",
 "metanetx.reaction":"MNXR142296",
@@ -52647,7 +52647,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15280",
+"gene_reaction_rule":"WP_014948150.1",
 "annotation":{
 "bigg.reaction":"OCTDPS",
 "biocyc":"META:RXN-8992",
@@ -52676,7 +52676,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18525",
+"gene_reaction_rule":"WP_014950167.1",
 "annotation":{
 "biocyc":"META:RXN-15878",
 "ec-code":"1.17.7.3",
@@ -52697,7 +52697,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11075",
+"gene_reaction_rule":"WP_014998704.1",
 "annotation":{
 "bigg.reaction":[
 "GLYt7",
@@ -52719,7 +52719,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13320",
+"gene_reaction_rule":"WP_049588135.1",
 "annotation":{
 "bigg.reaction":[
 "Clt",
@@ -52744,7 +52744,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03610",
+"gene_reaction_rule":"WP_049586122.1",
 "annotation":{
 "ec-code":"6.4.1.5",
 "kegg.orthology":[
@@ -52771,7 +52771,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10445 and TK37_RS19485",
+"gene_reaction_rule":"WP_049587504.1 and WP_012516907.1",
 "annotation":{
 "bigg.reaction":"HG2abcpp",
 "metanetx.reaction":"MNXR100623",
@@ -52791,7 +52791,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09110 and TK37_RS09130",
+"gene_reaction_rule":"WP_049587193.1 and WP_049587198.1",
 "annotation":{
 "biocyc":"META:RXN-15426",
 "ec-code":"2.8.2.37",
@@ -52813,7 +52813,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17600 and TK37_RS14480",
+"gene_reaction_rule":"WP_014950684.1 and WP_049588355.1",
 "annotation":{
 "biocyc":"META:RXN-3443",
 "ec-code":"1.2.1.3",
@@ -52832,7 +52832,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19715",
+"gene_reaction_rule":"WP_049589083.1",
 "annotation":{
 "kegg.orthology":"K01785",
 "kegg.reaction":"R10619",
@@ -52851,7 +52851,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14880",
+"gene_reaction_rule":"WP_014977810.1",
 "annotation":{
 "bigg.reaction":[
 "DHAD1",
@@ -52882,7 +52882,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01595",
+"gene_reaction_rule":"WP_014975995.1",
 "annotation":{
 "biocyc":"META:RXN-12093",
 "ec-code":"6.3.4.20",
@@ -52905,7 +52905,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01600",
+"gene_reaction_rule":"WP_014948788.1",
 "annotation":{
 "biocyc":"META:RXN0-6575",
 "ec-code":"4.3.99.3",
@@ -52930,7 +52930,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS04280",
+"gene_reaction_rule":"WP_049586240.1",
 "annotation":{
 "biocyc":"META:RXN0-5507",
 "ec-code":"4.1.2.50",
@@ -52957,7 +52957,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02775",
+"gene_reaction_rule":"WP_080986374.1",
 "annotation":{
 "ec-code":[
 "2.5.1.31",
@@ -52981,7 +52981,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02775",
+"gene_reaction_rule":"WP_080986374.1",
 "annotation":{
 "ec-code":[
 "2.5.1.31",
@@ -53007,7 +53007,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09180",
+"gene_reaction_rule":"WP_080986407.1",
 "annotation":{
 "bigg.reaction":[
 "THRt2pp",
@@ -53030,7 +53030,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS09180",
+"gene_reaction_rule":"WP_080986407.1",
 "annotation":{
 "bigg.reaction":[
 "HOMt",
@@ -53054,7 +53054,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08000",
+"gene_reaction_rule":"WP_039216400.1",
 "annotation":{
 "bigg.reaction":[
 "ACt4",
@@ -53081,7 +53081,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07910",
+"gene_reaction_rule":"WP_049586958.1",
 "annotation":{
 "biocyc":"META:RXN-11482",
 "ec-code":"1.3.1.10",
@@ -53101,7 +53101,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07910",
+"gene_reaction_rule":"WP_049586958.1",
 "annotation":{
 "biocyc":"META:RXN-11478",
 "ec-code":"1.3.1.10",
@@ -53124,7 +53124,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10930",
+"gene_reaction_rule":"WP_049587572.1",
 "annotation":{
 "biocyc":"META:PYRIMSYN1-RXN",
 "ec-code":"4.1.99.17",
@@ -53148,7 +53148,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19575",
+"gene_reaction_rule":"WP_014950514.1",
 "annotation":{
 "biocyc":"META:RXN-11566",
 "ec-code":[
@@ -53180,7 +53180,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS02180",
+"gene_reaction_rule":"WP_049585902.1",
 "annotation":{
 "biocyc":"META:2.8.1.6-RXN",
 "ec-code":"2.8.1.6",
@@ -53201,7 +53201,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11900",
+"gene_reaction_rule":"WP_014949953.1",
 "annotation":{
 "biocyc":"META:RXN-11479",
 "ec-code":"2.3.1.41",
@@ -53222,7 +53222,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07785",
+"gene_reaction_rule":"WP_049586946.1",
 "annotation":{
 "biocyc":"META:RXN-8974",
 "ec-code":[
@@ -53256,7 +53256,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS00415 and TK37_RS14950",
+"gene_reaction_rule":"WP_049585524.1 and WP_049588447.1",
 "annotation":{
 "bigg.reaction":[
 "HEMEOSm",
@@ -53287,7 +53287,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07795",
+"gene_reaction_rule":"WP_014950778.1",
 "annotation":{
 "kegg.orthology":"K09021",
 "kegg.reaction":"R09982",
@@ -53306,7 +53306,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS11020 and TK37_RS19130",
+"gene_reaction_rule":"WP_014949849.1 and WP_014979614.1",
 "annotation":{
 "biocyc":"META:DHDOGALDOL-RXN",
 "ec-code":[
@@ -53335,7 +53335,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18845",
+"gene_reaction_rule":"WP_049588978.1",
 "annotation":{
 "biocyc":"META:RXN0-5182",
 "ec-code":"2.4.1.1",
@@ -53357,7 +53357,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS01355 and TK37_RS10525 and TK37_RS16050",
+"gene_reaction_rule":"WP_049585802.1 and WP_049587489.1 and WP_049588633.1",
 "annotation":{
 "biocyc":"META:FLAVONADPREDUCT-RXN",
 "ec-code":[
@@ -53380,7 +53380,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS10495 and TK37_RS10490",
+"gene_reaction_rule":"WP_012516857.1 and WP_049587488.1",
 "annotation":{
 "biocyc":"META:RXN-16420",
 "metanetx.reaction":"MNXR120073",
@@ -53399,7 +53399,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS15275",
+"gene_reaction_rule":"WP_049588525.1",
 "annotation":{
 "biocyc":"META:TRANS-RXN-346",
 "sbo":"SBO:0000655",
@@ -55516,7 +55516,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16625"
+"gene_reaction_rule":"WP_049588698.1"
 },
 {
 "id":"lipoyl_synth",
@@ -55536,7 +55536,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12780 and TK37_RS16620",
+"gene_reaction_rule":"WP_014977033.1 and WP_049588697.1",
 "annotation":{
 "ec-code":"2.8.1.8",
 "kegg.orthology":"K03644",
@@ -55563,7 +55563,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS12750 and TK37_RS12785 and TK37_RS12755 and TK37_RS12760 and TK37_RS12765",
+"gene_reaction_rule":"WP_049588017.1 and WP_049588020.1 and WP_014950176.1 and WP_049588018.1 and WP_039228366.1",
 "annotation":{
 "sbo":"SBO:0000176"
 }
@@ -55579,7 +55579,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13175",
+"gene_reaction_rule":"WP_014950548.1",
 "annotation":{
 "bigg.reaction":"5DOAN",
 "ec-code":"3.2.2.9",
@@ -55634,7 +55634,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS20380",
+"gene_reaction_rule":"WP_049589208.1",
 "annotation":{
 "bigg.reaction":"GLUTRS",
 "ec-code":"6.1.1.17",
@@ -55662,7 +55662,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS17965",
+"gene_reaction_rule":"WP_014949017.1",
 "annotation":{
 "bigg.reaction":"GLUTRR",
 "ec-code":"1.2.1.70",
@@ -55723,7 +55723,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS16960",
+"gene_reaction_rule":"WP_049588741.1",
 "annotation":{
 "bigg.reaction":"PMDPHT",
 "biocyc":"META:RIBOPHOSPHAT-RXN",
@@ -55753,7 +55753,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS18945",
+"gene_reaction_rule":"WP_014977595.1",
 "annotation":{
 "bigg.reaction":"ASP1DC",
 "biocyc":"META:ASPDECARBOX-RXN",
@@ -55782,7 +55782,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS06805",
+"gene_reaction_rule":"WP_014950941.1",
 "annotation":{
 "bigg.reaction":"URFGTT",
 "biocyc":"META:RXN-14177",
@@ -55966,7 +55966,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07910",
+"gene_reaction_rule":"WP_049586958.1",
 "annotation":{
 "bigg.reaction":"EAR180y",
 "ec-code":"1.3.1.9",
@@ -55997,7 +55997,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS05910",
+"gene_reaction_rule":"WP_049586595.1",
 "annotation":{
 "bigg.reaction":"COBALT2abcpp",
 "metanetx.reaction":"MNXR96819",
@@ -56146,7 +56146,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19095",
+"gene_reaction_rule":"WP_039227034.1",
 "annotation":{
 "bigg.reaction":"GLYCTO1",
 "biocyc.reaction":"META:RXN-969",
@@ -56170,7 +56170,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS14480 or TK37_RS17600",
+"gene_reaction_rule":"WP_049588355.1 or WP_014950684.1",
 "annotation":{
 "bigg.reaction":"GCALDD",
 "biocyc":"META:GLYCOLALD-DEHYDROG-RXN",
@@ -56327,7 +56327,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS08515 and TK37_RS16235",
+"gene_reaction_rule":"WP_049587081.1 and WP_014949660.1",
 "annotation":{
 "biocyc":"META:DIHYDRODIPICSYN-RXN",
 "ec-code":"4.3.3.7",
@@ -56350,7 +56350,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS07050",
+"gene_reaction_rule":"WP_014976121.1",
 "annotation":{
 "kegg.reaction":"R04199",
 "sbo":"SBO:0000176",
@@ -56415,7 +56415,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13115",
+"gene_reaction_rule":"WP_049588093.1",
 "annotation":{
 "biocyc":"META:RXN-8979",
 "ec-code":"4.2.1.117",
@@ -56433,7 +56433,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13120",
+"gene_reaction_rule":"WP_049588095.1",
 "annotation":{
 "biocyc":"META:RXN-8977",
 "ec-code":"5.3.3.-",
@@ -56455,7 +56455,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS13750 and TK37_RS14240",
+"gene_reaction_rule":"WP_049588222.1 and WP_014948070.1",
 "annotation":{
 "biocyc":"META:MERCAPYSTRANS-RXN",
 "ec-code":"2.8.1.2",
@@ -56507,7 +56507,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS19575",
+"gene_reaction_rule":"WP_014950514.1",
 "annotation":{
 "bigg.reaction":"SACCD2",
 "biocyc":"META:1.5.1.7-RXN",
@@ -56551,7 +56551,7 @@
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"TK37_RS03165",
+"gene_reaction_rule":"WP_049586037.1",
 "annotation":{
 "biocyc":"META:RXN-16267",
 "sbo":"SBO:0000176",
@@ -56607,7 +56607,7 @@
 },
 {
 "id":"WP_049587105.1",
-"name":"G_TK37_RS08665",
+"name":"G_WP_049587105.1",
 "annotation":{
 "refseq":"WP_049587105.1",
 "sbo":"SBO:0000243"
@@ -56615,7 +56615,7 @@
 },
 {
 "id":"WP_049586269.1",
-"name":"G_TK37_RS04425",
+"name":"G_WP_049586269.1",
 "annotation":{
 "refseq":"WP_049586269.1",
 "sbo":"SBO:0000243"
@@ -56623,7 +56623,7 @@
 },
 {
 "id":"WP_049586267.1",
-"name":"G_TK37_RS04420",
+"name":"G_WP_049586267.1",
 "annotation":{
 "refseq":"WP_049586267.1",
 "sbo":"SBO:0000243"
@@ -56631,7 +56631,7 @@
 },
 {
 "id":"WP_014949139.1",
-"name":"G_TK37_RS05485",
+"name":"G_WP_014949139.1",
 "annotation":{
 "refseq":"WP_014949139.1",
 "sbo":"SBO:0000243"
@@ -56655,7 +56655,7 @@
 },
 {
 "id":"WP_049589131.1",
-"name":"G_TK37_RS19985",
+"name":"G_WP_049589131.1",
 "annotation":{
 "refseq":"WP_049589131.1",
 "sbo":"SBO:0000243"
@@ -56663,7 +56663,7 @@
 },
 {
 "id":"WP_014976668.1",
-"name":"G_TK37_RS16320",
+"name":"G_WP_014976668.1",
 "annotation":{
 "refseq":"WP_014976668.1",
 "sbo":"SBO:0000243"
@@ -56671,7 +56671,7 @@
 },
 {
 "id":"WP_014976833.1",
-"name":"G_TK37_RS19165",
+"name":"G_WP_014976833.1",
 "annotation":{
 "refseq":"WP_014976833.1",
 "sbo":"SBO:0000243"
@@ -56687,7 +56687,7 @@
 },
 {
 "id":"WP_039225570.1",
-"name":"G_TK37_RS11825",
+"name":"G_WP_039225570.1",
 "annotation":{
 "refseq":"WP_039225570.1",
 "sbo":"SBO:0000243"
@@ -56695,7 +56695,7 @@
 },
 {
 "id":"WP_039225252.1",
-"name":"G_TK37_RS11830",
+"name":"G_WP_039225252.1",
 "annotation":{
 "refseq":"WP_039225252.1",
 "sbo":"SBO:0000243"
@@ -56703,7 +56703,7 @@
 },
 {
 "id":"WP_049587062.1",
-"name":"G_TK37_RS08435",
+"name":"G_WP_049587062.1",
 "annotation":{
 "refseq":"WP_049587062.1",
 "sbo":"SBO:0000243"
@@ -56711,7 +56711,7 @@
 },
 {
 "id":"WP_049587639.1",
-"name":"G_TK37_RS11220",
+"name":"G_WP_049587639.1",
 "annotation":{
 "refseq":"WP_049587639.1",
 "sbo":"SBO:0000243"
@@ -56727,7 +56727,7 @@
 },
 {
 "id":"WP_049586144.1",
-"name":"G_TK37_RS03755",
+"name":"G_WP_049586144.1",
 "annotation":{
 "refseq":"WP_049586144.1",
 "sbo":"SBO:0000243"
@@ -56735,7 +56735,7 @@
 },
 {
 "id":"WP_049588937.1",
-"name":"G_TK37_RS18545",
+"name":"G_WP_049588937.1",
 "annotation":{
 "refseq":"WP_049588937.1",
 "sbo":"SBO:0000243"
@@ -56743,7 +56743,7 @@
 },
 {
 "id":"WP_080986367.1",
-"name":"G_TK37_RS01400",
+"name":"G_WP_080986367.1",
 "annotation":{
 "refseq":"WP_080986367.1",
 "sbo":"SBO:0000243"
@@ -56751,7 +56751,7 @@
 },
 {
 "id":"WP_049588021.1",
-"name":"G_TK37_RS12790",
+"name":"G_WP_049588021.1",
 "annotation":{
 "refseq":"WP_049588021.1",
 "sbo":"SBO:0000243"
@@ -56759,7 +56759,7 @@
 },
 {
 "id":"WP_049585467.1",
-"name":"G_TK37_RS00180",
+"name":"G_WP_049585467.1",
 "annotation":{
 "refseq":"WP_049585467.1",
 "sbo":"SBO:0000243"
@@ -56767,7 +56767,7 @@
 },
 {
 "id":"WP_014949030.1",
-"name":"G_TK37_RS18875",
+"name":"G_WP_014949030.1",
 "annotation":{
 "refseq":"WP_014949030.1",
 "sbo":"SBO:0000243"
@@ -56775,7 +56775,7 @@
 },
 {
 "id":"WP_049588640.1",
-"name":"G_TK37_RS16105",
+"name":"G_WP_049588640.1",
 "annotation":{
 "refseq":"WP_049588640.1",
 "sbo":"SBO:0000243"
@@ -56791,7 +56791,7 @@
 },
 {
 "id":"WP_049587157.1",
-"name":"G_TK37_RS08950",
+"name":"G_WP_049587157.1",
 "annotation":{
 "refseq":"WP_049587157.1",
 "sbo":"SBO:0000243"
@@ -56799,7 +56799,7 @@
 },
 {
 "id":"WP_080986386.1",
-"name":"G_TK37_RS04710",
+"name":"G_WP_080986386.1",
 "annotation":{
 "refseq":"WP_080986386.1",
 "sbo":"SBO:0000243"
@@ -56815,7 +56815,7 @@
 },
 {
 "id":"WP_049588707.1",
-"name":"G_TK37_RS16705",
+"name":"G_WP_049588707.1",
 "annotation":{
 "refseq":"WP_049588707.1",
 "sbo":"SBO:0000243"
@@ -56823,7 +56823,7 @@
 },
 {
 "id":"WP_049588754.1",
-"name":"G_TK37_RS17080",
+"name":"G_WP_049588754.1",
 "annotation":{
 "refseq":"WP_049588754.1",
 "sbo":"SBO:0000243"
@@ -56871,7 +56871,7 @@
 },
 {
 "id":"WP_049586716.1",
-"name":"G_TK37_RS06515",
+"name":"G_WP_049586716.1",
 "annotation":{
 "refseq":"WP_049586716.1",
 "sbo":"SBO:0000243"
@@ -56879,7 +56879,7 @@
 },
 {
 "id":"WP_049586236.1",
-"name":"G_TK37_RS04255",
+"name":"G_WP_049586236.1",
 "annotation":{
 "refseq":"WP_049586236.1",
 "sbo":"SBO:0000243"
@@ -56895,7 +56895,7 @@
 },
 {
 "id":"WP_049588781.1",
-"name":"G_TK37_RS17380",
+"name":"G_WP_049588781.1",
 "annotation":{
 "refseq":"WP_049588781.1",
 "sbo":"SBO:0000243"
@@ -56911,7 +56911,7 @@
 },
 {
 "id":"WP_049586604.1",
-"name":"G_TK37_RS06025",
+"name":"G_WP_049586604.1",
 "annotation":{
 "refseq":"WP_049586604.1",
 "sbo":"SBO:0000243"
@@ -56935,7 +56935,7 @@
 },
 {
 "id":"WP_053103828.1",
-"name":"G_TK37_RS20685",
+"name":"G_WP_053103828.1",
 "annotation":{
 "refseq":"WP_053103828.1",
 "sbo":"SBO:0000243"
@@ -56951,7 +56951,7 @@
 },
 {
 "id":"WP_080986400.1",
-"name":"G_TK37_RS07675",
+"name":"G_WP_080986400.1",
 "annotation":{
 "refseq":"WP_080986400.1",
 "sbo":"SBO:0000243"
@@ -56959,7 +56959,7 @@
 },
 {
 "id":"WP_049586533.1",
-"name":"G_TK37_RS05630",
+"name":"G_WP_049586533.1",
 "annotation":{
 "refseq":"WP_049586533.1",
 "sbo":"SBO:0000243"
@@ -56999,7 +56999,7 @@
 },
 {
 "id":"WP_014950808.1",
-"name":"G_TK37_RS07955",
+"name":"G_WP_014950808.1",
 "annotation":{
 "refseq":"WP_014950808.1",
 "sbo":"SBO:0000243"
@@ -57015,7 +57015,7 @@
 },
 {
 "id":"WP_049588900.1",
-"name":"G_TK37_RS18255",
+"name":"G_WP_049588900.1",
 "annotation":{
 "refseq":"WP_049588900.1",
 "sbo":"SBO:0000243"
@@ -57039,7 +57039,7 @@
 },
 {
 "id":"WP_049588592.1",
-"name":"G_TK37_RS15765",
+"name":"G_WP_049588592.1",
 "annotation":{
 "refseq":"WP_049588592.1",
 "sbo":"SBO:0000243"
@@ -57055,7 +57055,7 @@
 },
 {
 "id":"WP_049588331.1",
-"name":"G_TK37_RS14350",
+"name":"G_WP_049588331.1",
 "annotation":{
 "refseq":"WP_049588331.1",
 "sbo":"SBO:0000243"
@@ -57063,7 +57063,7 @@
 },
 {
 "id":"WP_044556927.1",
-"name":"G_TK37_RS02700",
+"name":"G_WP_044556927.1",
 "annotation":{
 "refseq":"WP_044556927.1",
 "sbo":"SBO:0000243"
@@ -57071,7 +57071,7 @@
 },
 {
 "id":"WP_049587731.1",
-"name":"G_TK37_RS11690",
+"name":"G_WP_049587731.1",
 "annotation":{
 "refseq":"WP_049587731.1",
 "sbo":"SBO:0000243"
@@ -57079,7 +57079,7 @@
 },
 {
 "id":"WP_049587772.1",
-"name":"G_TK37_RS11865",
+"name":"G_WP_049587772.1",
 "annotation":{
 "refseq":"WP_049587772.1",
 "sbo":"SBO:0000243"
@@ -57087,7 +57087,7 @@
 },
 {
 "id":"WP_049588110.1",
-"name":"G_TK37_RS13200",
+"name":"G_WP_049588110.1",
 "annotation":{
 "refseq":"WP_049588110.1",
 "sbo":"SBO:0000243"
@@ -57095,7 +57095,7 @@
 },
 {
 "id":"WP_049588449.1",
-"name":"G_TK37_RS14960",
+"name":"G_WP_049588449.1",
 "annotation":{
 "refseq":"WP_049588449.1",
 "sbo":"SBO:0000243"
@@ -57103,7 +57103,7 @@
 },
 {
 "id":"WP_014948922.1",
-"name":"G_TK37_RS02270",
+"name":"G_WP_014948922.1",
 "annotation":{
 "refseq":"WP_014948922.1",
 "sbo":"SBO:0000243"
@@ -57118,8 +57118,8 @@
 }
 },
 {
-"id":"TK37_RS14380",
-"name":"G_TK37_RS14380",
+"id":"WP_049588338.1",
+"name":"G_WP_049588338.1",
 "annotation":{
 "refseq":"WP_049588338.1",
 "sbo":"SBO:0000243"
@@ -57127,7 +57127,7 @@
 },
 {
 "id":"WP_049586246.1",
-"name":"G_TK37_RS04315",
+"name":"G_WP_049586246.1",
 "annotation":{
 "refseq":"WP_049586246.1",
 "sbo":"SBO:0000243"
@@ -57135,7 +57135,7 @@
 },
 {
 "id":"WP_049585859.1",
-"name":"G_TK37_RS01790",
+"name":"G_WP_049585859.1",
 "annotation":{
 "refseq":"WP_049585859.1",
 "sbo":"SBO:0000243"
@@ -57143,7 +57143,7 @@
 },
 {
 "id":"WP_039227930.1",
-"name":"G_TK37_RS03265",
+"name":"G_WP_039227930.1",
 "annotation":{
 "refseq":"WP_039227930.1",
 "sbo":"SBO:0000243"
@@ -57151,7 +57151,7 @@
 },
 {
 "id":"WP_039231048.1",
-"name":"G_TK37_RS14285",
+"name":"G_WP_039231048.1",
 "annotation":{
 "refseq":"WP_039231048.1",
 "sbo":"SBO:0000243"
@@ -57159,7 +57159,7 @@
 },
 {
 "id":"WP_020744244.1",
-"name":"G_TK37_RS17625",
+"name":"G_WP_020744244.1",
 "annotation":{
 "refseq":"WP_020744244.1",
 "sbo":"SBO:0000243"
@@ -57167,7 +57167,7 @@
 },
 {
 "id":"WP_049587504.1",
-"name":"G_TK37_RS10445",
+"name":"G_WP_049587504.1",
 "annotation":{
 "refseq":"WP_049587504.1",
 "sbo":"SBO:0000243"
@@ -57175,7 +57175,7 @@
 },
 {
 "id":"WP_012516907.1",
-"name":"G_TK37_RS19485",
+"name":"G_WP_012516907.1",
 "annotation":{
 "refseq":"WP_012516907.1",
 "sbo":"SBO:0000243"
@@ -57231,7 +57231,7 @@
 },
 {
 "id":"WP_014950051.1",
-"name":"G_TK37_RS16035",
+"name":"G_WP_014950051.1",
 "annotation":{
 "refseq":"WP_014950051.1",
 "sbo":"SBO:0000243"
@@ -57247,7 +57247,7 @@
 },
 {
 "id":"WP_012518362.1",
-"name":"G_TK37_RS15975",
+"name":"G_WP_012518362.1",
 "annotation":{
 "refseq":"WP_012518362.1",
 "sbo":"SBO:0000243"
@@ -57287,7 +57287,7 @@
 },
 {
 "id":"WP_049588248.1",
-"name":"G_TK37_RS13935",
+"name":"G_WP_049588248.1",
 "annotation":{
 "refseq":"WP_049588248.1",
 "sbo":"SBO:0000243"
@@ -57295,7 +57295,7 @@
 },
 {
 "id":"WP_014948557.1",
-"name":"G_TK37_RS02780",
+"name":"G_WP_014948557.1",
 "annotation":{
 "refseq":"WP_014948557.1",
 "sbo":"SBO:0000243"
@@ -57327,7 +57327,7 @@
 },
 {
 "id":"WP_014950089.1",
-"name":"G_TK37_RS06005",
+"name":"G_WP_014950089.1",
 "annotation":{
 "refseq":"WP_014950089.1",
 "sbo":"SBO:0000243"
@@ -57335,7 +57335,7 @@
 },
 {
 "id":"WP_049589075.1",
-"name":"G_TK37_RS19680",
+"name":"G_WP_049589075.1",
 "annotation":{
 "refseq":"WP_049589075.1",
 "sbo":"SBO:0000243"
@@ -57343,7 +57343,7 @@
 },
 {
 "id":"WP_049588435.1",
-"name":"G_TK37_RS14835",
+"name":"G_WP_049588435.1",
 "annotation":{
 "refseq":"WP_049588435.1",
 "sbo":"SBO:0000243"
@@ -57351,7 +57351,7 @@
 },
 {
 "id":"WP_039229281.1",
-"name":"G_TK37_RS17275",
+"name":"G_WP_039229281.1",
 "annotation":{
 "refseq":"WP_039229281.1",
 "sbo":"SBO:0000243"
@@ -57359,7 +57359,7 @@
 },
 {
 "id":"WP_049588403.1",
-"name":"G_TK37_RS14675",
+"name":"G_WP_049588403.1",
 "annotation":{
 "refseq":"WP_049588403.1",
 "sbo":"SBO:0000243"
@@ -57375,7 +57375,7 @@
 },
 {
 "id":"WP_049586019.1",
-"name":"G_TK37_RS03035",
+"name":"G_WP_049586019.1",
 "annotation":{
 "refseq":"WP_049586019.1",
 "sbo":"SBO:0000243"
@@ -57383,7 +57383,7 @@
 },
 {
 "id":"WP_049585588.1",
-"name":"G_TK37_RS00600",
+"name":"G_WP_049585588.1",
 "annotation":{
 "refseq":"WP_049585588.1",
 "sbo":"SBO:0000243"
@@ -57391,7 +57391,7 @@
 },
 {
 "id":"WP_014950548.1",
-"name":"G_TK37_RS13175",
+"name":"G_WP_014950548.1",
 "annotation":{
 "refseq":"WP_014950548.1",
 "sbo":"SBO:0000243"
@@ -57407,7 +57407,7 @@
 },
 {
 "id":"WP_049586260.1",
-"name":"G_TK37_RS04390",
+"name":"G_WP_049586260.1",
 "annotation":{
 "refseq":"WP_049586260.1",
 "sbo":"SBO:0000243"
@@ -57415,7 +57415,7 @@
 },
 {
 "id":"WP_049588717.1",
-"name":"G_TK37_RS16795",
+"name":"G_WP_049588717.1",
 "annotation":{
 "refseq":"WP_049588717.1",
 "sbo":"SBO:0000243"
@@ -57423,7 +57423,7 @@
 },
 {
 "id":"WP_049586168.1",
-"name":"G_TK37_RS03910",
+"name":"G_WP_049586168.1",
 "annotation":{
 "refseq":"WP_049586168.1",
 "sbo":"SBO:0000243"
@@ -57431,7 +57431,7 @@
 },
 {
 "id":"WP_049586127.1",
-"name":"G_TK37_RS03640",
+"name":"G_WP_049586127.1",
 "annotation":{
 "refseq":"WP_049586127.1",
 "sbo":"SBO:0000243"
@@ -57439,7 +57439,7 @@
 },
 {
 "id":"WP_014947861.1",
-"name":"G_TK37_RS08525",
+"name":"G_WP_014947861.1",
 "annotation":{
 "refseq":"WP_014947861.1",
 "sbo":"SBO:0000243"
@@ -57447,7 +57447,7 @@
 },
 {
 "id":"WP_049586190.1",
-"name":"G_TK37_RS04050",
+"name":"G_WP_049586190.1",
 "annotation":{
 "refseq":"WP_049586190.1",
 "sbo":"SBO:0000243"
@@ -57455,7 +57455,7 @@
 },
 {
 "id":"WP_049587825.1",
-"name":"G_TK37_RS12045",
+"name":"G_WP_049587825.1",
 "annotation":{
 "refseq":"WP_049587825.1",
 "sbo":"SBO:0000243"
@@ -57463,7 +57463,7 @@
 },
 {
 "id":"WP_014949348.1",
-"name":"G_TK37_RS16635",
+"name":"G_WP_014949348.1",
 "annotation":{
 "refseq":"WP_014949348.1",
 "sbo":"SBO:0000243"
@@ -57471,7 +57471,7 @@
 },
 {
 "id":"WP_039224609.1",
-"name":"G_TK37_RS04130",
+"name":"G_WP_039224609.1",
 "annotation":{
 "refseq":"WP_039224609.1",
 "sbo":"SBO:0000243"
@@ -57495,7 +57495,7 @@
 },
 {
 "id":"WP_049588784.1",
-"name":"G_TK37_RS17405",
+"name":"G_WP_049588784.1",
 "annotation":{
 "refseq":"WP_049588784.1",
 "sbo":"SBO:0000243"
@@ -57511,7 +57511,7 @@
 },
 {
 "id":"WP_049587218.1",
-"name":"G_TK37_RS09195",
+"name":"G_WP_049587218.1",
 "annotation":{
 "refseq":"WP_049587218.1",
 "sbo":"SBO:0000243"
@@ -57519,7 +57519,7 @@
 },
 {
 "id":"WP_015066029.1",
-"name":"G_TK37_RS10360",
+"name":"G_WP_015066029.1",
 "annotation":{
 "refseq":"WP_015066029.1",
 "sbo":"SBO:0000243"
@@ -57527,7 +57527,7 @@
 },
 {
 "id":"WP_014976618.1",
-"name":"G_TK37_RS13625",
+"name":"G_WP_014976618.1",
 "annotation":{
 "refseq":"WP_014976618.1",
 "sbo":"SBO:0000243"
@@ -57551,7 +57551,7 @@
 },
 {
 "id":"WP_014948475.1",
-"name":"G_TK37_RS02440",
+"name":"G_WP_014948475.1",
 "annotation":{
 "refseq":"WP_014948475.1",
 "sbo":"SBO:0000243"
@@ -57575,7 +57575,7 @@
 },
 {
 "id":"WP_049588978.1",
-"name":"G_TK37_RS18845",
+"name":"G_WP_049588978.1",
 "annotation":{
 "refseq":"WP_049588978.1",
 "sbo":"SBO:0000243"
@@ -57583,7 +57583,7 @@
 },
 {
 "id":"WP_049587853.1",
-"name":"G_TK37_RS12160",
+"name":"G_WP_049587853.1",
 "annotation":{
 "refseq":"WP_049587853.1",
 "sbo":"SBO:0000243"
@@ -57655,7 +57655,7 @@
 },
 {
 "id":"WP_039229648.1",
-"name":"G_TK37_RS17035",
+"name":"G_WP_039229648.1",
 "annotation":{
 "refseq":"WP_039229648.1",
 "sbo":"SBO:0000243"
@@ -57663,7 +57663,7 @@
 },
 {
 "id":"WP_049587312.1",
-"name":"G_TK37_RS09595",
+"name":"G_WP_049587312.1",
 "annotation":{
 "refseq":"WP_049587312.1",
 "sbo":"SBO:0000243"
@@ -57671,7 +57671,7 @@
 },
 {
 "id":"WP_014949212.1",
-"name":"G_TK37_RS16985",
+"name":"G_WP_014949212.1",
 "annotation":{
 "refseq":"WP_014949212.1",
 "sbo":"SBO:0000243"
@@ -57703,7 +57703,7 @@
 },
 {
 "id":"WP_049585628.1",
-"name":"G_TK37_RS00755",
+"name":"G_WP_049585628.1",
 "annotation":{
 "refseq":"WP_049585628.1",
 "sbo":"SBO:0000243"
@@ -57711,7 +57711,7 @@
 },
 {
 "id":"WP_049586525.1",
-"name":"G_TK37_RS05595",
+"name":"G_WP_049586525.1",
 "annotation":{
 "refseq":"WP_049586525.1",
 "sbo":"SBO:0000243"
@@ -57735,7 +57735,7 @@
 },
 {
 "id":"WP_049588755.1",
-"name":"G_TK37_RS17085",
+"name":"G_WP_049588755.1",
 "annotation":{
 "refseq":"WP_049588755.1",
 "sbo":"SBO:0000243"
@@ -57759,7 +57759,7 @@
 },
 {
 "id":"WP_014948790.1",
-"name":"G_TK37_RS01610",
+"name":"G_WP_014948790.1",
 "annotation":{
 "refseq":"WP_014948790.1",
 "sbo":"SBO:0000243"
@@ -57783,7 +57783,7 @@
 },
 {
 "id":"WP_039227752.1",
-"name":"G_TK37_RS04250",
+"name":"G_WP_039227752.1",
 "annotation":{
 "refseq":"WP_039227752.1",
 "sbo":"SBO:0000243"
@@ -57807,7 +57807,7 @@
 },
 {
 "id":"WP_049588313.1",
-"name":"G_TK37_RS14220",
+"name":"G_WP_049588313.1",
 "annotation":{
 "refseq":"WP_049588313.1",
 "sbo":"SBO:0000243"
@@ -57823,7 +57823,7 @@
 },
 {
 "id":"WP_039222269.1",
-"name":"G_TK37_RS20170",
+"name":"G_WP_039222269.1",
 "annotation":{
 "refseq":"WP_039222269.1",
 "sbo":"SBO:0000243"
@@ -57831,7 +57831,7 @@
 },
 {
 "id":"WP_014951276.1",
-"name":"G_TK37_RS00330",
+"name":"G_WP_014951276.1",
 "annotation":{
 "refseq":"WP_014951276.1",
 "sbo":"SBO:0000243"
@@ -57871,7 +57871,7 @@
 },
 {
 "id":"WP_049586730.1",
-"name":"G_TK37_RS06570",
+"name":"G_WP_049586730.1",
 "annotation":{
 "refseq":"WP_049586730.1",
 "sbo":"SBO:0000243"
@@ -57887,7 +57887,7 @@
 },
 {
 "id":"WP_014947786.1",
-"name":"G_TK37_RS10875",
+"name":"G_WP_014947786.1",
 "annotation":{
 "refseq":"WP_014947786.1",
 "sbo":"SBO:0000243"
@@ -57895,7 +57895,7 @@
 },
 {
 "id":"WP_049587019.1",
-"name":"G_TK37_RS08230",
+"name":"G_WP_049587019.1",
 "annotation":{
 "refseq":"WP_049587019.1",
 "sbo":"SBO:0000243"
@@ -57903,7 +57903,7 @@
 },
 {
 "id":"WP_049587262.1",
-"name":"G_TK37_RS09355",
+"name":"G_WP_049587262.1",
 "annotation":{
 "refseq":"WP_049587262.1",
 "sbo":"SBO:0000243"
@@ -57911,7 +57911,7 @@
 },
 {
 "id":"WP_049589161.1",
-"name":"G_TK37_RS20075",
+"name":"G_WP_049589161.1",
 "annotation":{
 "refseq":"WP_049589161.1",
 "sbo":"SBO:0000243"
@@ -57919,7 +57919,7 @@
 },
 {
 "id":"WP_014949232.1",
-"name":"G_TK37_RS17090",
+"name":"G_WP_014949232.1",
 "annotation":{
 "refseq":"WP_014949232.1",
 "sbo":"SBO:0000243"
@@ -57927,7 +57927,7 @@
 },
 {
 "id":"WP_049587138.1",
-"name":"G_TK37_RS08845",
+"name":"G_WP_049587138.1",
 "annotation":{
 "refseq":"WP_049587138.1",
 "sbo":"SBO:0000243"
@@ -57935,7 +57935,7 @@
 },
 {
 "id":"WP_014976690.1",
-"name":"G_TK37_RS18115",
+"name":"G_WP_014976690.1",
 "annotation":{
 "refseq":"WP_014976690.1",
 "sbo":"SBO:0000243"
@@ -57943,7 +57943,7 @@
 },
 {
 "id":"WP_049587170.1",
-"name":"G_TK37_RS09010",
+"name":"G_WP_049587170.1",
 "annotation":{
 "refseq":"WP_049587170.1",
 "sbo":"SBO:0000243"
@@ -57983,7 +57983,7 @@
 },
 {
 "id":"WP_014951193.1",
-"name":"G_TK37_RS00615",
+"name":"G_WP_014951193.1",
 "annotation":{
 "refseq":"WP_014951193.1",
 "sbo":"SBO:0000243"
@@ -57991,7 +57991,7 @@
 },
 {
 "id":"WP_049585822.1",
-"name":"G_TK37_RS01435",
+"name":"G_WP_049585822.1",
 "annotation":{
 "refseq":"WP_049585822.1",
 "sbo":"SBO:0000243"
@@ -57999,7 +57999,7 @@
 },
 {
 "id":"WP_049586048.1",
-"name":"G_TK37_RS03285",
+"name":"G_WP_049586048.1",
 "annotation":{
 "refseq":"WP_049586048.1",
 "sbo":"SBO:0000243"
@@ -58007,7 +58007,7 @@
 },
 {
 "id":"WP_012516834.1",
-"name":"G_TK37_RS10590",
+"name":"G_WP_012516834.1",
 "annotation":{
 "refseq":"WP_012516834.1",
 "sbo":"SBO:0000243"
@@ -58015,7 +58015,7 @@
 },
 {
 "id":"WP_049587498.1",
-"name":"G_TK37_RS10595",
+"name":"G_WP_049587498.1",
 "annotation":{
 "refseq":"WP_049587498.1",
 "sbo":"SBO:0000243"
@@ -58023,7 +58023,7 @@
 },
 {
 "id":"WP_039227932.1",
-"name":"G_TK37_RS03275",
+"name":"G_WP_039227932.1",
 "annotation":{
 "refseq":"WP_039227932.1",
 "sbo":"SBO:0000243"
@@ -58031,7 +58031,7 @@
 },
 {
 "id":"WP_014996986.1",
-"name":"G_TK37_RS10600",
+"name":"G_WP_014996986.1",
 "annotation":{
 "refseq":"WP_014996986.1",
 "sbo":"SBO:0000243"
@@ -58039,7 +58039,7 @@
 },
 {
 "id":"WP_049586047.1",
-"name":"G_TK37_RS03280",
+"name":"G_WP_049586047.1",
 "annotation":{
 "refseq":"WP_049586047.1",
 "sbo":"SBO:0000243"
@@ -58055,7 +58055,7 @@
 },
 {
 "id":"WP_049586785.1",
-"name":"G_TK37_RS07010",
+"name":"G_WP_049586785.1",
 "annotation":{
 "refseq":"WP_049586785.1",
 "sbo":"SBO:0000243"
@@ -58070,7 +58070,7 @@
 }
 },
 {
-"id":"TK37_RS10990",
+"id":"WP_014949855.1",
 "name":"pyk",
 "annotation":{
 "refseq":"WP_014949855.1",
@@ -58135,7 +58135,7 @@
 },
 {
 "id":"WP_080986474.1",
-"name":"G_TK37_RS18815",
+"name":"G_WP_080986474.1",
 "annotation":{
 "refseq":"WP_080986474.1",
 "sbo":"SBO:0000243"
@@ -58143,7 +58143,7 @@
 },
 {
 "id":"WP_049585669.1",
-"name":"G_TK37_RS00905",
+"name":"G_WP_049585669.1",
 "annotation":{
 "refseq":"WP_049585669.1",
 "sbo":"SBO:0000243"
@@ -58167,7 +58167,7 @@
 },
 {
 "id":"WP_039226924.1",
-"name":"G_TK37_RS10945",
+"name":"G_WP_039226924.1",
 "annotation":{
 "refseq":"WP_039226924.1",
 "sbo":"SBO:0000243"
@@ -58175,7 +58175,7 @@
 },
 {
 "id":"WP_049588954.1",
-"name":"G_TK37_RS18685",
+"name":"G_WP_049588954.1",
 "annotation":{
 "refseq":"WP_049588954.1",
 "sbo":"SBO:0000243"
@@ -58183,7 +58183,7 @@
 },
 {
 "id":"WP_014976911.1",
-"name":"G_TK37_RS11765",
+"name":"G_WP_014976911.1",
 "annotation":{
 "refseq":"WP_014976911.1",
 "sbo":"SBO:0000243"
@@ -58191,7 +58191,7 @@
 },
 {
 "id":"WP_014948837.1",
-"name":"G_TK37_RS01845",
+"name":"G_WP_014948837.1",
 "annotation":{
 "refseq":"WP_014948837.1",
 "sbo":"SBO:0000243"
@@ -58207,7 +58207,7 @@
 },
 {
 "id":"WP_049588635.1",
-"name":"G_TK37_RS16075",
+"name":"G_WP_049588635.1",
 "annotation":{
 "refseq":"WP_049588635.1",
 "sbo":"SBO:0000243"
@@ -58215,7 +58215,7 @@
 },
 {
 "id":"WP_014948348.1",
-"name":"G_TK37_RS03915",
+"name":"G_WP_014948348.1",
 "annotation":{
 "refseq":"WP_014948348.1",
 "sbo":"SBO:0000243"
@@ -58223,7 +58223,7 @@
 },
 {
 "id":"WP_049585898.1",
-"name":"G_TK37_RS02150",
+"name":"G_WP_049585898.1",
 "annotation":{
 "refseq":"WP_049585898.1",
 "sbo":"SBO:0000243"
@@ -58239,7 +58239,7 @@
 },
 {
 "id":"WP_049587271.1",
-"name":"G_TK37_RS09410",
+"name":"G_WP_049587271.1",
 "annotation":{
 "refseq":"WP_049587271.1",
 "sbo":"SBO:0000243"
@@ -58263,7 +58263,7 @@
 },
 {
 "id":"WP_049586958.1",
-"name":"G_TK37_RS07910",
+"name":"G_WP_049586958.1",
 "annotation":{
 "refseq":"WP_049586958.1",
 "sbo":"SBO:0000243"
@@ -58271,7 +58271,7 @@
 },
 {
 "id":"WP_049588217.1",
-"name":"G_TK37_RS13690",
+"name":"G_WP_049588217.1",
 "annotation":{
 "refseq":"WP_049588217.1",
 "sbo":"SBO:0000243"
@@ -58279,7 +58279,7 @@
 },
 {
 "id":"WP_049586488.1",
-"name":"G_TK37_RS05460",
+"name":"G_WP_049586488.1",
 "annotation":{
 "refseq":"WP_049586488.1",
 "sbo":"SBO:0000243"
@@ -58287,7 +58287,7 @@
 },
 {
 "id":"WP_049588376.1",
-"name":"G_TK37_RS14575",
+"name":"G_WP_049588376.1",
 "annotation":{
 "refseq":"WP_049588376.1",
 "sbo":"SBO:0000243"
@@ -58295,7 +58295,7 @@
 },
 {
 "id":"WP_049586601.1",
-"name":"G_TK37_RS05985",
+"name":"G_WP_049586601.1",
 "annotation":{
 "refseq":"WP_049586601.1",
 "sbo":"SBO:0000243"
@@ -58319,7 +58319,7 @@
 },
 {
 "id":"WP_049586453.1",
-"name":"G_TK37_RS05300",
+"name":"G_WP_049586453.1",
 "annotation":{
 "refseq":"WP_049586453.1",
 "sbo":"SBO:0000243"
@@ -58335,7 +58335,7 @@
 },
 {
 "id":"WP_049588791.1",
-"name":"G_TK37_RS17430",
+"name":"G_WP_049588791.1",
 "annotation":{
 "refseq":"WP_049588791.1",
 "sbo":"SBO:0000243"
@@ -58343,7 +58343,7 @@
 },
 {
 "id":"WP_049587985.1",
-"name":"G_TK37_RS12580",
+"name":"G_WP_049587985.1",
 "annotation":{
 "refseq":"WP_049587985.1",
 "sbo":"SBO:0000243"
@@ -58359,7 +58359,7 @@
 },
 {
 "id":"WP_049586742.1",
-"name":"G_TK37_RS06740",
+"name":"G_WP_049586742.1",
 "annotation":{
 "refseq":"WP_049586742.1",
 "sbo":"SBO:0000243"
@@ -58367,7 +58367,7 @@
 },
 {
 "id":"WP_049588588.1",
-"name":"G_TK37_RS15745",
+"name":"G_WP_049588588.1",
 "annotation":{
 "refseq":"WP_049588588.1",
 "sbo":"SBO:0000243"
@@ -58375,7 +58375,7 @@
 },
 {
 "id":"WP_049587342.1",
-"name":"G_TK37_RS09780",
+"name":"G_WP_049587342.1",
 "annotation":{
 "refseq":"WP_049587342.1",
 "sbo":"SBO:0000243"
@@ -58383,7 +58383,7 @@
 },
 {
 "id":"WP_014977336.1",
-"name":"G_TK37_RS13445",
+"name":"G_WP_014977336.1",
 "annotation":{
 "refseq":"WP_014977336.1",
 "sbo":"SBO:0000243"
@@ -58391,7 +58391,7 @@
 },
 {
 "id":"WP_049588907.1",
-"name":"G_TK37_RS18295",
+"name":"G_WP_049588907.1",
 "annotation":{
 "refseq":"WP_049588907.1",
 "sbo":"SBO:0000243"
@@ -58399,7 +58399,7 @@
 },
 {
 "id":"WP_049586860.1",
-"name":"G_TK37_RS07135",
+"name":"G_WP_049586860.1",
 "annotation":{
 "refseq":"WP_049586860.1",
 "sbo":"SBO:0000243"
@@ -58407,7 +58407,7 @@
 },
 {
 "id":"WP_049588854.1",
-"name":"G_TK37_RS17935",
+"name":"G_WP_049588854.1",
 "annotation":{
 "refseq":"WP_049588854.1",
 "sbo":"SBO:0000243"
@@ -58415,7 +58415,7 @@
 },
 {
 "id":"WP_049585984.1",
-"name":"G_TK37_RS02785",
+"name":"G_WP_049585984.1",
 "annotation":{
 "refseq":"WP_049585984.1",
 "sbo":"SBO:0000243"
@@ -58423,7 +58423,7 @@
 },
 {
 "id":"WP_049586069.1",
-"name":"G_TK37_RS03400",
+"name":"G_WP_049586069.1",
 "annotation":{
 "refseq":"WP_049586069.1",
 "sbo":"SBO:0000243"
@@ -58431,7 +58431,7 @@
 },
 {
 "id":"WP_049586187.1",
-"name":"G_TK37_RS04040",
+"name":"G_WP_049586187.1",
 "annotation":{
 "refseq":"WP_049586187.1",
 "sbo":"SBO:0000243"
@@ -58455,7 +58455,7 @@
 },
 {
 "id":"WP_049585624.1",
-"name":"G_TK37_RS00735",
+"name":"G_WP_049585624.1",
 "annotation":{
 "refseq":"WP_049585624.1",
 "sbo":"SBO:0000243"
@@ -58463,7 +58463,7 @@
 },
 {
 "id":"WP_049586232.1",
-"name":"G_TK37_RS04220",
+"name":"G_WP_049586232.1",
 "annotation":{
 "refseq":"WP_049586232.1",
 "sbo":"SBO:0000243"
@@ -58471,7 +58471,7 @@
 },
 {
 "id":"WP_049586628.1",
-"name":"G_TK37_RS06150",
+"name":"G_WP_049586628.1",
 "annotation":{
 "refseq":"WP_049586628.1",
 "sbo":"SBO:0000243"
@@ -58479,7 +58479,7 @@
 },
 {
 "id":"WP_049587083.1",
-"name":"G_TK37_RS08530",
+"name":"G_WP_049587083.1",
 "annotation":{
 "refseq":"WP_049587083.1",
 "sbo":"SBO:0000243"
@@ -58495,7 +58495,7 @@
 },
 {
 "id":"WP_014950684.1",
-"name":"G_TK37_RS17600",
+"name":"G_WP_014950684.1",
 "annotation":{
 "refseq":"WP_014950684.1",
 "sbo":"SBO:0000243"
@@ -58503,7 +58503,7 @@
 },
 {
 "id":"WP_049588355.1",
-"name":"G_TK37_RS14480",
+"name":"G_WP_049588355.1",
 "annotation":{
 "refseq":"WP_049588355.1",
 "sbo":"SBO:0000243"
@@ -58527,7 +58527,7 @@
 },
 {
 "id":"WP_049586830.1",
-"name":"G_TK37_RS07225",
+"name":"G_WP_049586830.1",
 "annotation":{
 "refseq":"WP_049586830.1",
 "sbo":"SBO:0000243"
@@ -58535,7 +58535,7 @@
 },
 {
 "id":"WP_049586828.1",
-"name":"G_TK37_RS07220",
+"name":"G_WP_049586828.1",
 "annotation":{
 "refseq":"WP_049586828.1",
 "sbo":"SBO:0000243"
@@ -58559,7 +58559,7 @@
 },
 {
 "id":"WP_049587892.1",
-"name":"G_TK37_RS12305",
+"name":"G_WP_049587892.1",
 "annotation":{
 "refseq":"WP_049587892.1",
 "sbo":"SBO:0000243"
@@ -58575,7 +58575,7 @@
 },
 {
 "id":"WP_049586804.1",
-"name":"G_TK37_RS07115",
+"name":"G_WP_049586804.1",
 "annotation":{
 "refseq":"WP_049586804.1",
 "sbo":"SBO:0000243"
@@ -58591,7 +58591,7 @@
 },
 {
 "id":"WP_014951296.1",
-"name":"G_TK37_RS00210",
+"name":"G_WP_014951296.1",
 "annotation":{
 "refseq":"WP_014951296.1",
 "sbo":"SBO:0000243"
@@ -58615,7 +58615,7 @@
 },
 {
 "id":"WP_049588843.1",
-"name":"G_TK37_RS17765",
+"name":"G_WP_049588843.1",
 "annotation":{
 "refseq":"WP_049588843.1",
 "sbo":"SBO:0000243"
@@ -58631,7 +58631,7 @@
 },
 {
 "id":"WP_049586704.1",
-"name":"G_TK37_RS06490",
+"name":"G_WP_049586704.1",
 "annotation":{
 "refseq":"WP_049586704.1",
 "sbo":"SBO:0000243"
@@ -58639,7 +58639,7 @@
 },
 {
 "id":"WP_014948004.1",
-"name":"G_TK37_RS15450",
+"name":"G_WP_014948004.1",
 "annotation":{
 "refseq":"WP_014948004.1",
 "sbo":"SBO:0000243"
@@ -58655,7 +58655,7 @@
 },
 {
 "id":"WP_049588363.1",
-"name":"G_TK37_RS14510",
+"name":"G_WP_049588363.1",
 "annotation":{
 "refseq":"WP_049588363.1",
 "sbo":"SBO:0000243"
@@ -58679,7 +58679,7 @@
 },
 {
 "id":"WP_049586270.1",
-"name":"G_TK37_RS04430",
+"name":"G_WP_049586270.1",
 "annotation":{
 "refseq":"WP_049586270.1",
 "sbo":"SBO:0000243"
@@ -58687,7 +58687,7 @@
 },
 {
 "id":"WP_039227034.1",
-"name":"G_TK37_RS19095",
+"name":"G_WP_039227034.1",
 "annotation":{
 "refseq":"WP_039227034.1",
 "sbo":"SBO:0000243"
@@ -58703,7 +58703,7 @@
 },
 {
 "id":"WP_049588512.1",
-"name":"G_TK37_RS15160",
+"name":"G_WP_049588512.1",
 "annotation":{
 "refseq":"WP_049588512.1",
 "sbo":"SBO:0000243"
@@ -58719,7 +58719,7 @@
 },
 {
 "id":"WP_049587894.1",
-"name":"G_TK37_RS12310",
+"name":"G_WP_049587894.1",
 "annotation":{
 "refseq":"WP_049587894.1",
 "sbo":"SBO:0000243"
@@ -58727,7 +58727,7 @@
 },
 {
 "id":"WP_049587891.1",
-"name":"G_TK37_RS12300",
+"name":"G_WP_049587891.1",
 "annotation":{
 "refseq":"WP_049587891.1",
 "sbo":"SBO:0000243"
@@ -58735,7 +58735,7 @@
 },
 {
 "id":"WP_049588124.1",
-"name":"G_TK37_RS13255",
+"name":"G_WP_049588124.1",
 "annotation":{
 "refseq":"WP_049588124.1",
 "sbo":"SBO:0000243"
@@ -58743,7 +58743,7 @@
 },
 {
 "id":"WP_041693510.1",
-"name":"G_TK37_RS18655",
+"name":"G_WP_041693510.1",
 "annotation":{
 "refseq":"WP_041693510.1",
 "sbo":"SBO:0000243"
@@ -58759,7 +58759,7 @@
 },
 {
 "id":"WP_049588842.1",
-"name":"G_TK37_RS17755",
+"name":"G_WP_049588842.1",
 "annotation":{
 "refseq":"WP_049588842.1",
 "sbo":"SBO:0000243"
@@ -58767,7 +58767,7 @@
 },
 {
 "id":"WP_049586277.1",
-"name":"G_TK37_RS04455",
+"name":"G_WP_049586277.1",
 "annotation":{
 "refseq":"WP_049586277.1",
 "sbo":"SBO:0000243"
@@ -58775,7 +58775,7 @@
 },
 {
 "id":"WP_014947725.1",
-"name":"G_TK37_RS04785",
+"name":"G_WP_014947725.1",
 "annotation":{
 "refseq":"WP_014947725.1",
 "sbo":"SBO:0000243"
@@ -58807,7 +58807,7 @@
 },
 {
 "id":"WP_049586519.1",
-"name":"G_TK37_RS05575",
+"name":"G_WP_049586519.1",
 "annotation":{
 "refseq":"WP_049586519.1",
 "sbo":"SBO:0000243"
@@ -58831,7 +58831,7 @@
 },
 {
 "id":"WP_014949660.1",
-"name":"G_TK37_RS16235",
+"name":"G_WP_014949660.1",
 "annotation":{
 "refseq":"WP_014949660.1",
 "sbo":"SBO:0000243"
@@ -58839,7 +58839,7 @@
 },
 {
 "id":"WP_039227754.1",
-"name":"G_TK37_RS04240",
+"name":"G_WP_039227754.1",
 "annotation":{
 "refseq":"WP_039227754.1",
 "sbo":"SBO:0000243"
@@ -58847,7 +58847,7 @@
 },
 {
 "id":"WP_049588165.1",
-"name":"G_TK37_RS13400",
+"name":"G_WP_049588165.1",
 "annotation":{
 "refseq":"WP_049588165.1",
 "sbo":"SBO:0000243"
@@ -58871,7 +58871,7 @@
 },
 {
 "id":"WP_049587884.1",
-"name":"G_TK37_RS12285",
+"name":"G_WP_049587884.1",
 "annotation":{
 "refseq":"WP_049587884.1",
 "sbo":"SBO:0000243"
@@ -58879,7 +58879,7 @@
 },
 {
 "id":"WP_049587992.1",
-"name":"G_TK37_RS12600",
+"name":"G_WP_049587992.1",
 "annotation":{
 "refseq":"WP_049587992.1",
 "sbo":"SBO:0000243"
@@ -58895,7 +58895,7 @@
 },
 {
 "id":"WP_049586608.1",
-"name":"G_TK37_RS06065",
+"name":"G_WP_049586608.1",
 "annotation":{
 "refseq":"WP_049586608.1",
 "sbo":"SBO:0000243"
@@ -58903,7 +58903,7 @@
 },
 {
 "id":"WP_049586203.1",
-"name":"G_TK37_RS04110",
+"name":"G_WP_049586203.1",
 "annotation":{
 "refseq":"WP_049586203.1",
 "sbo":"SBO:0000243"
@@ -58911,7 +58911,7 @@
 },
 {
 "id":"WP_080986402.1",
-"name":"G_TK37_RS08380",
+"name":"G_WP_080986402.1",
 "annotation":{
 "refseq":"WP_080986402.1",
 "sbo":"SBO:0000243"
@@ -58935,7 +58935,7 @@
 },
 {
 "id":"WP_049586295.1",
-"name":"G_TK37_RS04545",
+"name":"G_WP_049586295.1",
 "annotation":{
 "refseq":"WP_049586295.1",
 "sbo":"SBO:0000243"
@@ -58943,7 +58943,7 @@
 },
 {
 "id":"WP_049587007.1",
-"name":"G_TK37_RS08185",
+"name":"G_WP_049587007.1",
 "annotation":{
 "refseq":"WP_049587007.1",
 "sbo":"SBO:0000243"
@@ -58951,7 +58951,7 @@
 },
 {
 "id":"WP_039225748.1",
-"name":"G_TK37_RS07295",
+"name":"G_WP_039225748.1",
 "annotation":{
 "refseq":"WP_039225748.1",
 "sbo":"SBO:0000243"
@@ -58959,7 +58959,7 @@
 },
 {
 "id":"WP_049588994.1",
-"name":"G_TK37_RS18925",
+"name":"G_WP_049588994.1",
 "annotation":{
 "refseq":"WP_049588994.1",
 "sbo":"SBO:0000243"
@@ -58967,7 +58967,7 @@
 },
 {
 "id":"WP_039226913.1",
-"name":"G_TK37_RS08785",
+"name":"G_WP_039226913.1",
 "annotation":{
 "refseq":"WP_039226913.1",
 "sbo":"SBO:0000243"
@@ -58975,7 +58975,7 @@
 },
 {
 "id":"WP_014980522.1",
-"name":"G_TK37_RS17185",
+"name":"G_WP_014980522.1",
 "annotation":{
 "refseq":"WP_014980522.1",
 "sbo":"SBO:0000243"
@@ -58983,7 +58983,7 @@
 },
 {
 "id":"WP_039233285.1",
-"name":"G_TK37_RS11370",
+"name":"G_WP_039233285.1",
 "annotation":{
 "refseq":"WP_039233285.1",
 "sbo":"SBO:0000243"
@@ -58991,7 +58991,7 @@
 },
 {
 "id":"WP_039230569.1",
-"name":"G_TK37_RS02610",
+"name":"G_WP_039230569.1",
 "annotation":{
 "refseq":"WP_039230569.1",
 "sbo":"SBO:0000243"
@@ -58999,7 +58999,7 @@
 },
 {
 "id":"WP_049585907.1",
-"name":"G_TK37_RS02215",
+"name":"G_WP_049585907.1",
 "annotation":{
 "refseq":"WP_049585907.1",
 "sbo":"SBO:0000243"
@@ -59007,7 +59007,7 @@
 },
 {
 "id":"WP_080986363.1",
-"name":"G_TK37_RS00935",
+"name":"G_WP_080986363.1",
 "annotation":{
 "refseq":"WP_080986363.1",
 "sbo":"SBO:0000243"
@@ -59015,7 +59015,7 @@
 },
 {
 "id":"WP_049587998.1",
-"name":"G_TK37_RS12630",
+"name":"G_WP_049587998.1",
 "annotation":{
 "refseq":"WP_049587998.1",
 "sbo":"SBO:0000243"
@@ -59023,7 +59023,7 @@
 },
 {
 "id":"WP_049586686.1",
-"name":"G_TK37_RS06390",
+"name":"G_WP_049586686.1",
 "annotation":{
 "refseq":"WP_049586686.1",
 "sbo":"SBO:0000243"
@@ -59031,7 +59031,7 @@
 },
 {
 "id":"WP_049588904.1",
-"name":"G_TK37_RS18275",
+"name":"G_WP_049588904.1",
 "annotation":{
 "refseq":"WP_049588904.1",
 "sbo":"SBO:0000243"
@@ -59047,7 +59047,7 @@
 },
 {
 "id":"WP_049589153.1",
-"name":"G_TK37_RS20050",
+"name":"G_WP_049589153.1",
 "annotation":{
 "refseq":"WP_049589153.1",
 "sbo":"SBO:0000243"
@@ -59063,7 +59063,7 @@
 },
 {
 "id":"WP_014950978.1",
-"name":"G_TK37_RS19395",
+"name":"G_WP_014950978.1",
 "annotation":{
 "refseq":"WP_014950978.1",
 "sbo":"SBO:0000243"
@@ -59095,7 +59095,7 @@
 },
 {
 "id":"WP_080986462.1",
-"name":"G_TK37_RS16735",
+"name":"G_WP_080986462.1",
 "annotation":{
 "refseq":"WP_080986462.1",
 "sbo":"SBO:0000243"
@@ -59103,7 +59103,7 @@
 },
 {
 "id":"WP_049586194.1",
-"name":"G_TK37_RS04060",
+"name":"G_WP_049586194.1",
 "annotation":{
 "refseq":"WP_049586194.1",
 "sbo":"SBO:0000243"
@@ -59111,7 +59111,7 @@
 },
 {
 "id":"WP_014949228.1",
-"name":"G_TK37_RS17070",
+"name":"G_WP_014949228.1",
 "annotation":{
 "refseq":"WP_014949228.1",
 "sbo":"SBO:0000243"
@@ -59119,7 +59119,7 @@
 },
 {
 "id":"WP_014980177.1",
-"name":"G_TK37_RS13910",
+"name":"G_WP_014980177.1",
 "annotation":{
 "refseq":"WP_014980177.1",
 "sbo":"SBO:0000243"
@@ -59143,7 +59143,7 @@
 },
 {
 "id":"WP_014949945.1",
-"name":"G_TK37_RS20110",
+"name":"G_WP_014949945.1",
 "annotation":{
 "refseq":"WP_014949945.1",
 "sbo":"SBO:0000243"
@@ -59151,7 +59151,7 @@
 },
 {
 "id":"WP_039228347.1",
-"name":"G_TK37_RS18460",
+"name":"G_WP_039228347.1",
 "annotation":{
 "refseq":"WP_039228347.1",
 "sbo":"SBO:0000243"
@@ -59159,7 +59159,7 @@
 },
 {
 "id":"WP_049588677.1",
-"name":"G_TK37_RS16445",
+"name":"G_WP_049588677.1",
 "annotation":{
 "refseq":"WP_049588677.1",
 "sbo":"SBO:0000243"
@@ -59175,7 +59175,7 @@
 },
 {
 "id":"WP_049588115.1",
-"name":"G_TK37_RS13225",
+"name":"G_WP_049588115.1",
 "annotation":{
 "refseq":"WP_049588115.1",
 "sbo":"SBO:0000243"
@@ -59183,7 +59183,7 @@
 },
 {
 "id":"WP_049588642.1",
-"name":"G_TK37_RS16115",
+"name":"G_WP_049588642.1",
 "annotation":{
 "refseq":"WP_049588642.1",
 "sbo":"SBO:0000243"
@@ -59191,7 +59191,7 @@
 },
 {
 "id":"WP_049587613.1",
-"name":"G_TK37_RS11110",
+"name":"G_WP_049587613.1",
 "annotation":{
 "refseq":"WP_049587613.1",
 "sbo":"SBO:0000243"
@@ -59199,7 +59199,7 @@
 },
 {
 "id":"WP_014949849.1",
-"name":"G_TK37_RS11020",
+"name":"G_WP_014949849.1",
 "annotation":{
 "refseq":"WP_014949849.1",
 "sbo":"SBO:0000243"
@@ -59239,7 +59239,7 @@
 },
 {
 "id":"WP_049588570.1",
-"name":"G_TK37_RS15645",
+"name":"G_WP_049588570.1",
 "annotation":{
 "refseq":"WP_049588570.1",
 "sbo":"SBO:0000243"
@@ -59247,7 +59247,7 @@
 },
 {
 "id":"WP_014948685.1",
-"name":"G_TK37_RS11415",
+"name":"G_WP_014948685.1",
 "annotation":{
 "refseq":"WP_014948685.1",
 "sbo":"SBO:0000243"
@@ -59255,7 +59255,7 @@
 },
 {
 "id":"WP_039236747.1",
-"name":"G_TK37_RS08840",
+"name":"G_WP_039236747.1",
 "annotation":{
 "refseq":"WP_039236747.1",
 "sbo":"SBO:0000243"
@@ -59263,7 +59263,7 @@
 },
 {
 "id":"WP_014950960.1",
-"name":"G_TK37_RS06900",
+"name":"G_WP_014950960.1",
 "annotation":{
 "refseq":"WP_014950960.1",
 "sbo":"SBO:0000243"
@@ -59271,7 +59271,7 @@
 },
 {
 "id":"WP_080986381.1",
-"name":"G_TK37_RS03730",
+"name":"G_WP_080986381.1",
 "annotation":{
 "refseq":"WP_080986381.1",
 "sbo":"SBO:0000243"
@@ -59303,7 +59303,7 @@
 },
 {
 "id":"WP_049587284.1",
-"name":"G_TK37_RS09465",
+"name":"G_WP_049587284.1",
 "annotation":{
 "refseq":"WP_049587284.1",
 "sbo":"SBO:0000243"
@@ -59319,7 +59319,7 @@
 },
 {
 "id":"WP_049588605.1",
-"name":"G_TK37_RS15835",
+"name":"G_WP_049588605.1",
 "annotation":{
 "refseq":"WP_049588605.1",
 "sbo":"SBO:0000243"
@@ -59335,7 +59335,7 @@
 },
 {
 "id":"WP_049585748.1",
-"name":"G_TK37_RS00590",
+"name":"G_WP_049585748.1",
 "annotation":{
 "refseq":"WP_049585748.1",
 "sbo":"SBO:0000243"
@@ -59375,7 +59375,7 @@
 },
 {
 "id":"WP_014950809.1",
-"name":"G_TK37_RS07960",
+"name":"G_WP_014950809.1",
 "annotation":{
 "refseq":"WP_014950809.1",
 "sbo":"SBO:0000243"
@@ -59383,7 +59383,7 @@
 },
 {
 "id":"WP_049586872.1",
-"name":"G_TK37_RS07400",
+"name":"G_WP_049586872.1",
 "annotation":{
 "refseq":"WP_049586872.1",
 "sbo":"SBO:0000243"
@@ -59391,7 +59391,7 @@
 },
 {
 "id":"WP_049586959.1",
-"name":"G_TK37_RS07920",
+"name":"G_WP_049586959.1",
 "annotation":{
 "refseq":"WP_049586959.1",
 "sbo":"SBO:0000243"
@@ -59399,7 +59399,7 @@
 },
 {
 "id":"WP_014977204.1",
-"name":"G_TK37_RS03535",
+"name":"G_WP_014977204.1",
 "annotation":{
 "refseq":"WP_014977204.1",
 "sbo":"SBO:0000243"
@@ -59431,7 +59431,7 @@
 },
 {
 "id":"WP_049587335.1",
-"name":"G_TK37_RS09735",
+"name":"G_WP_049587335.1",
 "annotation":{
 "refseq":"WP_049587335.1",
 "sbo":"SBO:0000243"
@@ -59455,7 +59455,7 @@
 },
 {
 "id":"WP_049587668.1",
-"name":"G_TK37_RS11355",
+"name":"G_WP_049587668.1",
 "annotation":{
 "refseq":"WP_049587668.1",
 "sbo":"SBO:0000243"
@@ -59463,7 +59463,7 @@
 },
 {
 "id":"WP_049586864.1",
-"name":"G_TK37_RS07350",
+"name":"G_WP_049586864.1",
 "annotation":{
 "refseq":"WP_049586864.1",
 "sbo":"SBO:0000243"
@@ -59487,7 +59487,7 @@
 },
 {
 "id":"WP_049586292.1",
-"name":"G_TK37_RS04525",
+"name":"G_WP_049586292.1",
 "annotation":{
 "refseq":"WP_049586292.1",
 "sbo":"SBO:0000243"
@@ -59495,7 +59495,7 @@
 },
 {
 "id":"WP_049587777.1",
-"name":"G_TK37_RS11890",
+"name":"G_WP_049587777.1",
 "annotation":{
 "refseq":"WP_049587777.1",
 "sbo":"SBO:0000243"
@@ -59511,7 +59511,7 @@
 },
 {
 "id":"WP_080986475.1",
-"name":"G_TK37_RS19265",
+"name":"G_WP_080986475.1",
 "annotation":{
 "refseq":"WP_080986475.1",
 "sbo":"SBO:0000243"
@@ -59519,7 +59519,7 @@
 },
 {
 "id":"WP_014951321.1",
-"name":"G_TK37_RS00085",
+"name":"G_WP_014951321.1",
 "annotation":{
 "refseq":"WP_014951321.1",
 "sbo":"SBO:0000243"
@@ -59527,7 +59527,7 @@
 },
 {
 "id":"WP_049587678.1",
-"name":"G_TK37_RS11440",
+"name":"G_WP_049587678.1",
 "annotation":{
 "refseq":"WP_049587678.1",
 "sbo":"SBO:0000243"
@@ -59551,7 +59551,7 @@
 },
 {
 "id":"WP_014950261.1",
-"name":"G_TK37_RS08990",
+"name":"G_WP_014950261.1",
 "annotation":{
 "refseq":"WP_014950261.1",
 "sbo":"SBO:0000243"
@@ -59559,7 +59559,7 @@
 },
 {
 "id":"WP_049588908.1",
-"name":"G_TK37_RS18315",
+"name":"G_WP_049588908.1",
 "annotation":{
 "refseq":"WP_049588908.1",
 "sbo":"SBO:0000243"
@@ -59567,7 +59567,7 @@
 },
 {
 "id":"WP_014975277.1",
-"name":"G_TK37_RS10790",
+"name":"G_WP_014975277.1",
 "annotation":{
 "refseq":"WP_014975277.1",
 "sbo":"SBO:0000243"
@@ -59591,7 +59591,7 @@
 },
 {
 "id":"WP_049586032.1",
-"name":"G_TK37_RS03130",
+"name":"G_WP_049586032.1",
 "annotation":{
 "refseq":"WP_049586032.1",
 "sbo":"SBO:0000243"
@@ -59607,7 +59607,7 @@
 },
 {
 "id":"WP_049586255.1",
-"name":"G_TK37_RS04365",
+"name":"G_WP_049586255.1",
 "annotation":{
 "refseq":"WP_049586255.1",
 "sbo":"SBO:0000243"
@@ -59615,7 +59615,7 @@
 },
 {
 "id":"WP_049586254.1",
-"name":"G_TK37_RS04360",
+"name":"G_WP_049586254.1",
 "annotation":{
 "refseq":"WP_049586254.1",
 "sbo":"SBO:0000243"
@@ -59639,7 +59639,7 @@
 },
 {
 "id":"WP_049587293.1",
-"name":"G_TK37_RS09220",
+"name":"G_WP_049587293.1",
 "annotation":{
 "refseq":"WP_049587293.1",
 "sbo":"SBO:0000243"
@@ -59647,7 +59647,7 @@
 },
 {
 "id":"WP_049585647.1",
-"name":"G_TK37_RS00815",
+"name":"G_WP_049585647.1",
 "annotation":{
 "refseq":"WP_049585647.1",
 "sbo":"SBO:0000243"
@@ -59655,7 +59655,7 @@
 },
 {
 "id":"WP_049586820.1",
-"name":"G_TK37_RS07185",
+"name":"G_WP_049586820.1",
 "annotation":{
 "refseq":"WP_049586820.1",
 "sbo":"SBO:0000243"
@@ -59671,7 +59671,7 @@
 },
 {
 "id":"WP_014949721.1",
-"name":"G_TK37_RS18640",
+"name":"G_WP_014949721.1",
 "annotation":{
 "refseq":"WP_014949721.1",
 "sbo":"SBO:0000243"
@@ -59679,7 +59679,7 @@
 },
 {
 "id":"WP_049588230.1",
-"name":"G_TK37_RS13800",
+"name":"G_WP_049588230.1",
 "annotation":{
 "refseq":"WP_049588230.1",
 "sbo":"SBO:0000243"
@@ -59703,7 +59703,7 @@
 },
 {
 "id":"WP_049586880.1",
-"name":"G_TK37_RS07450",
+"name":"G_WP_049586880.1",
 "annotation":{
 "refseq":"WP_049586880.1",
 "sbo":"SBO:0000243"
@@ -59719,7 +59719,7 @@
 },
 {
 "id":"WP_049589117.1",
-"name":"G_TK37_RS19920",
+"name":"G_WP_049589117.1",
 "annotation":{
 "refseq":"WP_049589117.1",
 "sbo":"SBO:0000243"
@@ -59727,7 +59727,7 @@
 },
 {
 "id":"WP_049588315.1",
-"name":"G_TK37_RS14230",
+"name":"G_WP_049588315.1",
 "annotation":{
 "refseq":"WP_049588315.1",
 "sbo":"SBO:0000243"
@@ -59743,7 +59743,7 @@
 },
 {
 "id":"WP_049586192.1",
-"name":"G_TK37_RS04055",
+"name":"G_WP_049586192.1",
 "annotation":{
 "refseq":"WP_049586192.1",
 "sbo":"SBO:0000243"
@@ -59751,7 +59751,7 @@
 },
 {
 "id":"WP_014948109.1",
-"name":"G_TK37_RS14475",
+"name":"G_WP_014948109.1",
 "annotation":{
 "refseq":"WP_014948109.1",
 "sbo":"SBO:0000243"
@@ -59759,7 +59759,7 @@
 },
 {
 "id":"WP_014948664.1",
-"name":"G_TK37_RS11290",
+"name":"G_WP_014948664.1",
 "annotation":{
 "refseq":"WP_014948664.1",
 "sbo":"SBO:0000243"
@@ -59767,7 +59767,7 @@
 },
 {
 "id":"WP_049587792.1",
-"name":"G_TK37_RS11920",
+"name":"G_WP_049587792.1",
 "annotation":{
 "refseq":"WP_049587792.1",
 "sbo":"SBO:0000243"
@@ -59775,7 +59775,7 @@
 },
 {
 "id":"WP_014948054.1",
-"name":"G_TK37_RS14320",
+"name":"G_WP_014948054.1",
 "annotation":{
 "refseq":"WP_014948054.1",
 "sbo":"SBO:0000243"
@@ -59783,7 +59783,7 @@
 },
 {
 "id":"WP_049587269.1",
-"name":"G_TK37_RS09400",
+"name":"G_WP_049587269.1",
 "annotation":{
 "refseq":"WP_049587269.1",
 "sbo":"SBO:0000243"
@@ -59847,7 +59847,7 @@
 },
 {
 "id":"WP_014976150.1",
-"name":"G_TK37_RS17930",
+"name":"G_WP_014976150.1",
 "annotation":{
 "refseq":"WP_014976150.1",
 "sbo":"SBO:0000243"
@@ -59959,7 +59959,7 @@
 },
 {
 "id":"WP_049588729.1",
-"name":"G_TK37_RS16875",
+"name":"G_WP_049588729.1",
 "annotation":{
 "refseq":"WP_049588729.1",
 "sbo":"SBO:0000243"
@@ -59983,7 +59983,7 @@
 },
 {
 "id":"WP_049589231.1",
-"name":"G_TK37_RS20550",
+"name":"G_WP_049589231.1",
 "annotation":{
 "refseq":"WP_049589231.1",
 "sbo":"SBO:0000243"
@@ -60007,7 +60007,7 @@
 },
 {
 "id":"WP_049588258.1",
-"name":"G_TK37_RS13970",
+"name":"G_WP_049588258.1",
 "annotation":{
 "refseq":"WP_049588258.1",
 "sbo":"SBO:0000243"
@@ -60055,7 +60055,7 @@
 },
 {
 "id":"WP_014950559.1",
-"name":"G_TK37_RS13215",
+"name":"G_WP_014950559.1",
 "annotation":{
 "refseq":"WP_014950559.1",
 "sbo":"SBO:0000243"
@@ -60103,7 +60103,7 @@
 },
 {
 "id":"WP_049589203.1",
-"name":"G_TK37_RS20335",
+"name":"G_WP_049589203.1",
 "annotation":{
 "refseq":"WP_049589203.1",
 "sbo":"SBO:0000243"
@@ -60215,7 +60215,7 @@
 },
 {
 "id":"WP_039228916.1",
-"name":"G_TK37_RS04770",
+"name":"G_WP_039228916.1",
 "annotation":{
 "refseq":"WP_039228916.1",
 "sbo":"SBO:0000243"
@@ -60342,7 +60342,7 @@
 }
 },
 {
-"id":"TK37_RS06610",
+"id":"WP_012519217.1",
 "name":"rpmJ",
 "annotation":{
 "refseq":"WP_012519217.1",
@@ -60390,8 +60390,8 @@
 }
 },
 {
-"id":"TK37_RS07445",
-"name":"G_TK37_RS07445",
+"id":"WP_049586879.1",
+"name":"G_WP_049586879.1",
 "annotation":{
 "refseq":"WP_049586879.1",
 "sbo":"SBO:0000243"
@@ -60431,7 +60431,7 @@
 },
 {
 "id":"WP_049587399.1",
-"name":"G_TK37_RS10055",
+"name":"G_WP_049587399.1",
 "annotation":{
 "refseq":"WP_049587399.1",
 "sbo":"SBO:0000243"
@@ -60447,7 +60447,7 @@
 },
 {
 "id":"WP_049588753.1",
-"name":"G_TK37_RS17055",
+"name":"G_WP_049588753.1",
 "annotation":{
 "refseq":"WP_049588753.1",
 "sbo":"SBO:0000243"
@@ -60455,7 +60455,7 @@
 },
 {
 "id":"WP_014949007.1",
-"name":"G_TK37_RS17870",
+"name":"G_WP_014949007.1",
 "annotation":{
 "refseq":"WP_014949007.1",
 "sbo":"SBO:0000243"
@@ -60471,7 +60471,7 @@
 },
 {
 "id":"WP_049587578.1",
-"name":"G_TK37_RS10785",
+"name":"G_WP_049587578.1",
 "annotation":{
 "refseq":"WP_049587578.1",
 "sbo":"SBO:0000243"
@@ -60487,7 +60487,7 @@
 },
 {
 "id":"WP_049586052.1",
-"name":"G_TK37_RS03325",
+"name":"G_WP_049586052.1",
 "annotation":{
 "refseq":"WP_049586052.1",
 "sbo":"SBO:0000243"
@@ -60495,7 +60495,7 @@
 },
 {
 "id":"WP_049586784.1",
-"name":"G_TK37_RS07005",
+"name":"G_WP_049586784.1",
 "annotation":{
 "refseq":"WP_049586784.1",
 "sbo":"SBO:0000243"
@@ -60503,7 +60503,7 @@
 },
 {
 "id":"WP_053103824.1",
-"name":"G_TK37_RS13275",
+"name":"G_WP_053103824.1",
 "annotation":{
 "refseq":"WP_053103824.1",
 "sbo":"SBO:0000243"
@@ -60527,7 +60527,7 @@
 },
 {
 "id":"WP_049585955.1",
-"name":"G_TK37_RS02510",
+"name":"G_WP_049585955.1",
 "annotation":{
 "refseq":"WP_049585955.1",
 "sbo":"SBO:0000243"
@@ -60535,7 +60535,7 @@
 },
 {
 "id":"WP_049588839.1",
-"name":"G_TK37_RS17735",
+"name":"G_WP_049588839.1",
 "annotation":{
 "refseq":"WP_049588839.1",
 "sbo":"SBO:0000243"
@@ -60543,7 +60543,7 @@
 },
 {
 "id":"WP_049585438.1",
-"name":"G_TK37_RS00095",
+"name":"G_WP_049585438.1",
 "annotation":{
 "refseq":"WP_049585438.1",
 "sbo":"SBO:0000243"
@@ -60551,7 +60551,7 @@
 },
 {
 "id":"WP_049588590.1",
-"name":"G_TK37_RS15755",
+"name":"G_WP_049588590.1",
 "annotation":{
 "refseq":"WP_049588590.1",
 "sbo":"SBO:0000243"
@@ -60559,7 +60559,7 @@
 },
 {
 "id":"WP_049586233.1",
-"name":"G_TK37_RS04230",
+"name":"G_WP_049586233.1",
 "annotation":{
 "refseq":"WP_049586233.1",
 "sbo":"SBO:0000243"
@@ -60567,7 +60567,7 @@
 },
 {
 "id":"WP_049586624.1",
-"name":"G_TK37_RS06135",
+"name":"G_WP_049586624.1",
 "annotation":{
 "refseq":"WP_049586624.1",
 "sbo":"SBO:0000243"
@@ -60575,7 +60575,7 @@
 },
 {
 "id":"WP_049588824.1",
-"name":"G_TK37_RS17650",
+"name":"G_WP_049588824.1",
 "annotation":{
 "refseq":"WP_049588824.1",
 "sbo":"SBO:0000243"
@@ -60583,7 +60583,7 @@
 },
 {
 "id":"WP_039218556.1",
-"name":"G_TK37_RS03540",
+"name":"G_WP_039218556.1",
 "annotation":{
 "refseq":"WP_039218556.1",
 "sbo":"SBO:0000243"
@@ -60591,7 +60591,7 @@
 },
 {
 "id":"WP_014950772.1",
-"name":"G_TK37_RS07765",
+"name":"G_WP_014950772.1",
 "annotation":{
 "refseq":"WP_014950772.1",
 "sbo":"SBO:0000243"
@@ -60599,7 +60599,7 @@
 },
 {
 "id":"WP_049588336.1",
-"name":"G_TK37_RS14370",
+"name":"G_WP_049588336.1",
 "annotation":{
 "refseq":"WP_049588336.1",
 "sbo":"SBO:0000243"
@@ -60607,7 +60607,7 @@
 },
 {
 "id":"WP_039225577.1",
-"name":"G_TK37_RS07625",
+"name":"G_WP_039225577.1",
 "annotation":{
 "refseq":"WP_039225577.1",
 "sbo":"SBO:0000243"
@@ -60615,7 +60615,7 @@
 },
 {
 "id":"WP_152910875.1",
-"name":"G_TK37_RS08115",
+"name":"G_WP_152910875.1",
 "annotation":{
 "refseq":"WP_152910875.1",
 "sbo":"SBO:0000243"
@@ -60623,7 +60623,7 @@
 },
 {
 "id":"WP_049586869.1",
-"name":"G_TK37_RS07380",
+"name":"G_WP_049586869.1",
 "annotation":{
 "refseq":"WP_049586869.1",
 "sbo":"SBO:0000243"
@@ -60663,7 +60663,7 @@
 },
 {
 "id":"WP_014998717.1",
-"name":"G_TK37_RS11010",
+"name":"G_WP_014998717.1",
 "annotation":{
 "refseq":"WP_014998717.1",
 "sbo":"SBO:0000243"
@@ -60671,7 +60671,7 @@
 },
 {
 "id":"WP_080986378.1",
-"name":"G_TK37_RS03525",
+"name":"G_WP_080986378.1",
 "annotation":{
 "refseq":"WP_080986378.1",
 "sbo":"SBO:0000243"
@@ -60695,7 +60695,7 @@
 },
 {
 "id":"WP_049585701.1",
-"name":"G_TK37_RS01080",
+"name":"G_WP_049585701.1",
 "annotation":{
 "refseq":"WP_049585701.1",
 "sbo":"SBO:0000243"
@@ -60703,7 +60703,7 @@
 },
 {
 "id":"WP_049588105.1",
-"name":"G_TK37_RS13150",
+"name":"G_WP_049588105.1",
 "annotation":{
 "refseq":"WP_049588105.1",
 "sbo":"SBO:0000243"
@@ -60711,7 +60711,7 @@
 },
 {
 "id":"WP_049589015.1",
-"name":"G_TK37_RS19125",
+"name":"G_WP_049589015.1",
 "annotation":{
 "refseq":"WP_049589015.1",
 "sbo":"SBO:0000243"
@@ -60719,7 +60719,7 @@
 },
 {
 "id":"WP_049588496.1",
-"name":"G_TK37_RS15185",
+"name":"G_WP_049588496.1",
 "annotation":{
 "refseq":"WP_049588496.1",
 "sbo":"SBO:0000243"
@@ -60727,7 +60727,7 @@
 },
 {
 "id":"WP_049587197.1",
-"name":"G_TK37_RS09125",
+"name":"G_WP_049587197.1",
 "annotation":{
 "refseq":"WP_049587197.1",
 "sbo":"SBO:0000243"
@@ -60735,7 +60735,7 @@
 },
 {
 "id":"WP_049588788.1",
-"name":"G_TK37_RS17360",
+"name":"G_WP_049588788.1",
 "annotation":{
 "refseq":"WP_049588788.1",
 "sbo":"SBO:0000243"
@@ -60767,7 +60767,7 @@
 },
 {
 "id":"WP_014950265.1",
-"name":"G_TK37_RS08970",
+"name":"G_WP_014950265.1",
 "annotation":{
 "refseq":"WP_014950265.1",
 "sbo":"SBO:0000243"
@@ -60807,7 +60807,7 @@
 },
 {
 "id":"WP_049585960.1",
-"name":"G_TK37_RS02550",
+"name":"G_WP_049585960.1",
 "annotation":{
 "refseq":"WP_049585960.1",
 "sbo":"SBO:0000243"
@@ -60815,7 +60815,7 @@
 },
 {
 "id":"WP_049586806.1",
-"name":"G_TK37_RS07120",
+"name":"G_WP_049586806.1",
 "annotation":{
 "refseq":"WP_049586806.1",
 "sbo":"SBO:0000243"
@@ -60823,7 +60823,7 @@
 },
 {
 "id":"WP_049585953.1",
-"name":"G_TK37_RS02500",
+"name":"G_WP_049585953.1",
 "annotation":{
 "refseq":"WP_049585953.1",
 "sbo":"SBO:0000243"
@@ -60847,7 +60847,7 @@
 },
 {
 "id":"WP_014948339.1",
-"name":"G_TK37_RS03865",
+"name":"G_WP_014948339.1",
 "annotation":{
 "refseq":"WP_014948339.1",
 "sbo":"SBO:0000243"
@@ -60855,7 +60855,7 @@
 },
 {
 "id":"WP_049586135.1",
-"name":"G_TK37_RS03705",
+"name":"G_WP_049586135.1",
 "annotation":{
 "refseq":"WP_049586135.1",
 "sbo":"SBO:0000243"
@@ -60911,7 +60911,7 @@
 },
 {
 "id":"WP_049586331.1",
-"name":"G_TK37_RS04680",
+"name":"G_WP_049586331.1",
 "annotation":{
 "refseq":"WP_049586331.1",
 "sbo":"SBO:0000243"
@@ -60927,7 +60927,7 @@
 },
 {
 "id":"WP_014980757.1",
-"name":"G_TK37_RS05235",
+"name":"G_WP_014980757.1",
 "annotation":{
 "refseq":"WP_014980757.1",
 "sbo":"SBO:0000243"
@@ -60935,7 +60935,7 @@
 },
 {
 "id":"WP_049587995.1",
-"name":"G_TK37_RS12610",
+"name":"G_WP_049587995.1",
 "annotation":{
 "refseq":"WP_049587995.1",
 "sbo":"SBO:0000243"
@@ -60943,7 +60943,7 @@
 },
 {
 "id":"WP_049588550.1",
-"name":"G_TK37_RS15400",
+"name":"G_WP_049588550.1",
 "annotation":{
 "refseq":"WP_049588550.1",
 "sbo":"SBO:0000243"
@@ -60951,7 +60951,7 @@
 },
 {
 "id":"WP_049586043.1",
-"name":"G_TK37_RS03220",
+"name":"G_WP_049586043.1",
 "annotation":{
 "refseq":"WP_049586043.1",
 "sbo":"SBO:0000243"
@@ -60959,7 +60959,7 @@
 },
 {
 "id":"WP_014949867.1",
-"name":"G_TK37_RS19185",
+"name":"G_WP_014949867.1",
 "annotation":{
 "refseq":"WP_014949867.1",
 "sbo":"SBO:0000243"
@@ -60967,7 +60967,7 @@
 },
 {
 "id":"WP_049585855.1",
-"name":"G_TK37_RS01765",
+"name":"G_WP_049585855.1",
 "annotation":{
 "refseq":"WP_049585855.1",
 "sbo":"SBO:0000243"
@@ -60975,7 +60975,7 @@
 },
 {
 "id":"WP_049586739.1",
-"name":"G_TK37_RS06695",
+"name":"G_WP_049586739.1",
 "annotation":{
 "refseq":"WP_049586739.1",
 "sbo":"SBO:0000243"
@@ -60991,7 +60991,7 @@
 },
 {
 "id":"WP_014975732.1",
-"name":"G_TK37_RS03980",
+"name":"G_WP_014975732.1",
 "annotation":{
 "refseq":"WP_014975732.1",
 "sbo":"SBO:0000243"
@@ -61039,7 +61039,7 @@
 },
 {
 "id":"WP_014948985.1",
-"name":"G_TK37_RS07025",
+"name":"G_WP_014948985.1",
 "annotation":{
 "refseq":"WP_014948985.1",
 "sbo":"SBO:0000243"
@@ -61047,7 +61047,7 @@
 },
 {
 "id":"WP_049587314.1",
-"name":"G_TK37_RS09605",
+"name":"G_WP_049587314.1",
 "annotation":{
 "refseq":"WP_049587314.1",
 "sbo":"SBO:0000243"
@@ -61055,7 +61055,7 @@
 },
 {
 "id":"WP_049585734.1",
-"name":"G_TK37_RS01185",
+"name":"G_WP_049585734.1",
 "annotation":{
 "refseq":"WP_049585734.1",
 "sbo":"SBO:0000243"
@@ -61079,7 +61079,7 @@
 },
 {
 "id":"WP_049588841.1",
-"name":"G_TK37_RS17750",
+"name":"G_WP_049588841.1",
 "annotation":{
 "refseq":"WP_049588841.1",
 "sbo":"SBO:0000243"
@@ -61087,7 +61087,7 @@
 },
 {
 "id":"WP_049588490.1",
-"name":"G_TK37_RS15170",
+"name":"G_WP_049588490.1",
 "annotation":{
 "refseq":"WP_049588490.1",
 "sbo":"SBO:0000243"
@@ -61095,7 +61095,7 @@
 },
 {
 "id":"WP_080986391.1",
-"name":"G_TK37_RS05565",
+"name":"G_WP_080986391.1",
 "annotation":{
 "refseq":"WP_080986391.1",
 "sbo":"SBO:0000243"
@@ -61167,7 +61167,7 @@
 },
 {
 "id":"WP_049587676.1",
-"name":"G_TK37_RS11425",
+"name":"G_WP_049587676.1",
 "annotation":{
 "refseq":"WP_049587676.1",
 "sbo":"SBO:0000243"
@@ -61175,7 +61175,7 @@
 },
 {
 "id":"WP_049587727.1",
-"name":"G_TK37_RS11680",
+"name":"G_WP_049587727.1",
 "annotation":{
 "refseq":"WP_049587727.1",
 "sbo":"SBO:0000243"
@@ -61183,7 +61183,7 @@
 },
 {
 "id":"WP_049589151.1",
-"name":"G_TK37_RS20045",
+"name":"G_WP_049589151.1",
 "annotation":{
 "refseq":"WP_049589151.1",
 "sbo":"SBO:0000243"
@@ -61191,7 +61191,7 @@
 },
 {
 "id":"WP_014950090.1",
-"name":"G_TK37_RS06000",
+"name":"G_WP_014950090.1",
 "annotation":{
 "refseq":"WP_014950090.1",
 "sbo":"SBO:0000243"
@@ -61223,7 +61223,7 @@
 },
 {
 "id":"WP_049587790.1",
-"name":"G_TK37_RS11915",
+"name":"G_WP_049587790.1",
 "annotation":{
 "refseq":"WP_049587790.1",
 "sbo":"SBO:0000243"
@@ -61231,7 +61231,7 @@
 },
 {
 "id":"WP_049588184.1",
-"name":"G_TK37_RS13525",
+"name":"G_WP_049588184.1",
 "annotation":{
 "refseq":"WP_049588184.1",
 "sbo":"SBO:0000243"
@@ -61239,7 +61239,7 @@
 },
 {
 "id":"WP_012516877.1",
-"name":"G_TK37_RS10415",
+"name":"G_WP_012516877.1",
 "annotation":{
 "refseq":"WP_012516877.1",
 "sbo":"SBO:0000243"
@@ -61247,7 +61247,7 @@
 },
 {
 "id":"WP_012519580.1",
-"name":"G_TK37_RS13160",
+"name":"G_WP_012519580.1",
 "annotation":{
 "refseq":"WP_012519580.1",
 "sbo":"SBO:0000243"
@@ -61255,7 +61255,7 @@
 },
 {
 "id":"WP_014975770.1",
-"name":"G_TK37_RS04190",
+"name":"G_WP_014975770.1",
 "annotation":{
 "refseq":"WP_014975770.1",
 "sbo":"SBO:0000243"
@@ -61271,7 +61271,7 @@
 },
 {
 "id":"WP_049586503.1",
-"name":"G_TK37_RS05520",
+"name":"G_WP_049586503.1",
 "annotation":{
 "refseq":"WP_049586503.1",
 "sbo":"SBO:0000243"
@@ -61287,7 +61287,7 @@
 },
 {
 "id":"WP_049586522.1",
-"name":"G_TK37_RS05585",
+"name":"G_WP_049586522.1",
 "annotation":{
 "refseq":"WP_049586522.1",
 "sbo":"SBO:0000243"
@@ -61311,7 +61311,7 @@
 },
 {
 "id":"WP_049587759.1",
-"name":"G_TK37_RS11820",
+"name":"G_WP_049587759.1",
 "annotation":{
 "refseq":"WP_049587759.1",
 "sbo":"SBO:0000243"
@@ -61327,7 +61327,7 @@
 },
 {
 "id":"WP_049589092.1",
-"name":"G_TK37_RS19750",
+"name":"G_WP_049589092.1",
 "annotation":{
 "refseq":"WP_049589092.1",
 "sbo":"SBO:0000243"
@@ -61335,7 +61335,7 @@
 },
 {
 "id":"WP_014948274.1",
-"name":"G_TK37_RS08335",
+"name":"G_WP_014948274.1",
 "annotation":{
 "refseq":"WP_014948274.1",
 "sbo":"SBO:0000243"
@@ -61343,7 +61343,7 @@
 },
 {
 "id":"WP_049586622.1",
-"name":"G_TK37_RS06130",
+"name":"G_WP_049586622.1",
 "annotation":{
 "refseq":"WP_049586622.1",
 "sbo":"SBO:0000243"
@@ -61375,7 +61375,7 @@
 },
 {
 "id":"WP_049586234.1",
-"name":"G_TK37_RS04235",
+"name":"G_WP_049586234.1",
 "annotation":{
 "refseq":"WP_049586234.1",
 "sbo":"SBO:0000243"
@@ -61383,7 +61383,7 @@
 },
 {
 "id":"WP_014950446.1",
-"name":"G_TK37_RS03260",
+"name":"G_WP_014950446.1",
 "annotation":{
 "refseq":"WP_014950446.1",
 "sbo":"SBO:0000243"
@@ -61391,7 +61391,7 @@
 },
 {
 "id":"WP_014949715.1",
-"name":"G_TK37_RS18670",
+"name":"G_WP_014949715.1",
 "annotation":{
 "refseq":"WP_014949715.1",
 "sbo":"SBO:0000243"
@@ -61415,7 +61415,7 @@
 },
 {
 "id":"WP_049589179.1",
-"name":"G_TK37_RS20165",
+"name":"G_WP_049589179.1",
 "annotation":{
 "refseq":"WP_049589179.1",
 "sbo":"SBO:0000243"
@@ -61423,7 +61423,7 @@
 },
 {
 "id":"WP_014976864.1",
-"name":"G_TK37_RS07500",
+"name":"G_WP_014976864.1",
 "annotation":{
 "refseq":"WP_014976864.1",
 "sbo":"SBO:0000243"
@@ -61431,7 +61431,7 @@
 },
 {
 "id":"WP_049588787.1",
-"name":"G_TK37_RS17290",
+"name":"G_WP_049588787.1",
 "annotation":{
 "refseq":"WP_049588787.1",
 "sbo":"SBO:0000243"
@@ -61447,7 +61447,7 @@
 },
 {
 "id":"WP_014949528.1",
-"name":"G_TK37_RS04405",
+"name":"G_WP_014949528.1",
 "annotation":{
 "refseq":"WP_014949528.1",
 "sbo":"SBO:0000243"
@@ -61455,7 +61455,7 @@
 },
 {
 "id":"WP_049588132.1",
-"name":"G_TK37_RS13295",
+"name":"G_WP_049588132.1",
 "annotation":{
 "refseq":"WP_049588132.1",
 "sbo":"SBO:0000243"
@@ -61479,7 +61479,7 @@
 },
 {
 "id":"WP_014951084.1",
-"name":"G_TK37_RS01135",
+"name":"G_WP_014951084.1",
 "annotation":{
 "refseq":"WP_014951084.1",
 "sbo":"SBO:0000243"
@@ -61487,7 +61487,7 @@
 },
 {
 "id":"WP_049588309.1",
-"name":"G_TK37_RS14165",
+"name":"G_WP_049588309.1",
 "annotation":{
 "refseq":"WP_049588309.1",
 "sbo":"SBO:0000243"
@@ -61511,7 +61511,7 @@
 },
 {
 "id":"WP_049587876.1",
-"name":"G_TK37_RS12245",
+"name":"G_WP_049587876.1",
 "annotation":{
 "refseq":"WP_049587876.1",
 "sbo":"SBO:0000243"
@@ -61519,7 +61519,7 @@
 },
 {
 "id":"WP_039225111.1",
-"name":"G_TK37_RS19740",
+"name":"G_WP_039225111.1",
 "annotation":{
 "refseq":"WP_039225111.1",
 "sbo":"SBO:0000243"
@@ -61527,7 +61527,7 @@
 },
 {
 "id":"WP_049585584.1",
-"name":"G_TK37_RS00585",
+"name":"G_WP_049585584.1",
 "annotation":{
 "refseq":"WP_049585584.1",
 "sbo":"SBO:0000243"
@@ -61535,7 +61535,7 @@
 },
 {
 "id":"WP_049586550.1",
-"name":"G_TK37_RS05685",
+"name":"G_WP_049586550.1",
 "annotation":{
 "refseq":"WP_049586550.1",
 "sbo":"SBO:0000243"
@@ -61543,7 +61543,7 @@
 },
 {
 "id":"WP_049587238.1",
-"name":"G_TK37_RS09270",
+"name":"G_WP_049587238.1",
 "annotation":{
 "refseq":"WP_049587238.1",
 "sbo":"SBO:0000243"
@@ -61551,7 +61551,7 @@
 },
 {
 "id":"WP_049589018.1",
-"name":"G_TK37_RS19145",
+"name":"G_WP_049589018.1",
 "annotation":{
 "refseq":"WP_049589018.1",
 "sbo":"SBO:0000243"
@@ -61575,7 +61575,7 @@
 },
 {
 "id":"WP_045980005.1",
-"name":"G_TK37_RS04630",
+"name":"G_WP_045980005.1",
 "annotation":{
 "refseq":"WP_045980005.1",
 "sbo":"SBO:0000243"
@@ -61583,7 +61583,7 @@
 },
 {
 "id":"WP_012516887.1",
-"name":"G_TK37_RS10370",
+"name":"G_WP_012516887.1",
 "annotation":{
 "refseq":"WP_012516887.1",
 "sbo":"SBO:0000243"
@@ -61591,7 +61591,7 @@
 },
 {
 "id":"WP_039229202.1",
-"name":"G_TK37_RS00860",
+"name":"G_WP_039229202.1",
 "annotation":{
 "refseq":"WP_039229202.1",
 "sbo":"SBO:0000243"
@@ -61599,7 +61599,7 @@
 },
 {
 "id":"WP_045980004.1",
-"name":"G_TK37_RS04635",
+"name":"G_WP_045980004.1",
 "annotation":{
 "refseq":"WP_045980004.1",
 "sbo":"SBO:0000243"
@@ -61607,7 +61607,7 @@
 },
 {
 "id":"WP_049586517.1",
-"name":"G_TK37_RS05570",
+"name":"G_WP_049586517.1",
 "annotation":{
 "refseq":"WP_049586517.1",
 "sbo":"SBO:0000243"
@@ -61615,7 +61615,7 @@
 },
 {
 "id":"WP_049586521.1",
-"name":"G_TK37_RS05580",
+"name":"G_WP_049586521.1",
 "annotation":{
 "refseq":"WP_049586521.1",
 "sbo":"SBO:0000243"
@@ -61655,7 +61655,7 @@
 },
 {
 "id":"WP_049586823.1",
-"name":"G_TK37_RS07205",
+"name":"G_WP_049586823.1",
 "annotation":{
 "refseq":"WP_049586823.1",
 "sbo":"SBO:0000243"
@@ -61687,7 +61687,7 @@
 },
 {
 "id":"WP_049586968.1",
-"name":"G_TK37_RS07990",
+"name":"G_WP_049586968.1",
 "annotation":{
 "refseq":"WP_049586968.1",
 "sbo":"SBO:0000243"
@@ -61695,7 +61695,7 @@
 },
 {
 "id":"WP_049588632.1",
-"name":"G_TK37_RS16040",
+"name":"G_WP_049588632.1",
 "annotation":{
 "refseq":"WP_049588632.1",
 "sbo":"SBO:0000243"
@@ -61711,7 +61711,7 @@
 },
 {
 "id":"WP_080986472.1",
-"name":"G_TK37_RS18555",
+"name":"G_WP_080986472.1",
 "annotation":{
 "refseq":"WP_080986472.1",
 "sbo":"SBO:0000243"
@@ -61719,7 +61719,7 @@
 },
 {
 "id":"WP_049588749.1",
-"name":"G_TK37_RS17025",
+"name":"G_WP_049588749.1",
 "annotation":{
 "refseq":"WP_049588749.1",
 "sbo":"SBO:0000243"
@@ -61735,7 +61735,7 @@
 },
 {
 "id":"WP_012519633.1",
-"name":"G_TK37_RS13975",
+"name":"G_WP_012519633.1",
 "annotation":{
 "refseq":"WP_012519633.1",
 "sbo":"SBO:0000243"
@@ -61759,7 +61759,7 @@
 },
 {
 "id":"WP_049587032.1",
-"name":"G_TK37_RS08290",
+"name":"G_WP_049587032.1",
 "annotation":{
 "refseq":"WP_049587032.1",
 "sbo":"SBO:0000243"
@@ -61767,7 +61767,7 @@
 },
 {
 "id":"WP_049585499.1",
-"name":"G_TK37_RS00305",
+"name":"G_WP_049585499.1",
 "annotation":{
 "refseq":"WP_049585499.1",
 "sbo":"SBO:0000243"
@@ -61791,7 +61791,7 @@
 },
 {
 "id":"WP_049588563.1",
-"name":"G_TK37_RS15520",
+"name":"G_WP_049588563.1",
 "annotation":{
 "refseq":"WP_049588563.1",
 "sbo":"SBO:0000243"
@@ -61807,7 +61807,7 @@
 },
 {
 "id":"WP_049585952.1",
-"name":"G_TK37_RS02495",
+"name":"G_WP_049585952.1",
 "annotation":{
 "refseq":"WP_049585952.1",
 "sbo":"SBO:0000243"
@@ -61823,7 +61823,7 @@
 },
 {
 "id":"WP_014949014.1",
-"name":"G_TK37_RS17945",
+"name":"G_WP_014949014.1",
 "annotation":{
 "refseq":"WP_014949014.1",
 "sbo":"SBO:0000243"
@@ -61831,7 +61831,7 @@
 },
 {
 "id":"WP_049588855.1",
-"name":"G_TK37_RS17940",
+"name":"G_WP_049588855.1",
 "annotation":{
 "refseq":"WP_049588855.1",
 "sbo":"SBO:0000243"
@@ -61855,7 +61855,7 @@
 },
 {
 "id":"WP_049588566.1",
-"name":"G_TK37_RS15545",
+"name":"G_WP_049588566.1",
 "annotation":{
 "refseq":"WP_049588566.1",
 "sbo":"SBO:0000243"
@@ -61871,7 +61871,7 @@
 },
 {
 "id":"WP_049588361.1",
-"name":"G_TK37_RS14505",
+"name":"G_WP_049588361.1",
 "annotation":{
 "refseq":"WP_049588361.1",
 "sbo":"SBO:0000243"
@@ -61911,7 +61911,7 @@
 },
 {
 "id":"WP_049588117.1",
-"name":"G_TK37_RS13230",
+"name":"G_WP_049588117.1",
 "annotation":{
 "refseq":"WP_049588117.1",
 "sbo":"SBO:0000243"
@@ -61927,7 +61927,7 @@
 },
 {
 "id":"WP_049588207.1",
-"name":"G_TK37_RS13640",
+"name":"G_WP_049588207.1",
 "annotation":{
 "refseq":"WP_049588207.1",
 "sbo":"SBO:0000243"
@@ -61935,7 +61935,7 @@
 },
 {
 "id":"WP_049587551.1",
-"name":"G_TK37_RS10835",
+"name":"G_WP_049587551.1",
 "annotation":{
 "refseq":"WP_049587551.1",
 "sbo":"SBO:0000243"
@@ -61943,7 +61943,7 @@
 },
 {
 "id":"WP_049588136.1",
-"name":"G_TK37_RS13340",
+"name":"G_WP_049588136.1",
 "annotation":{
 "refseq":"WP_049588136.1",
 "sbo":"SBO:0000243"
@@ -61959,7 +61959,7 @@
 },
 {
 "id":"WP_049586790.1",
-"name":"G_TK37_RS07060",
+"name":"G_WP_049586790.1",
 "annotation":{
 "refseq":"WP_049586790.1",
 "sbo":"SBO:0000243"
@@ -61967,7 +61967,7 @@
 },
 {
 "id":"WP_049586389.1",
-"name":"G_TK37_RS05020",
+"name":"G_WP_049586389.1",
 "annotation":{
 "refseq":"WP_049586389.1",
 "sbo":"SBO:0000243"
@@ -61975,7 +61975,7 @@
 },
 {
 "id":"WP_049585649.1",
-"name":"G_TK37_RS00825",
+"name":"G_WP_049585649.1",
 "annotation":{
 "refseq":"WP_049585649.1",
 "sbo":"SBO:0000243"
@@ -61999,7 +61999,7 @@
 },
 {
 "id":"WP_049586810.1",
-"name":"G_TK37_RS07130",
+"name":"G_WP_049586810.1",
 "annotation":{
 "refseq":"WP_049586810.1",
 "sbo":"SBO:0000243"
@@ -62007,7 +62007,7 @@
 },
 {
 "id":"WP_049588882.1",
-"name":"G_TK37_RS18165",
+"name":"G_WP_049588882.1",
 "annotation":{
 "refseq":"WP_049588882.1",
 "sbo":"SBO:0000243"
@@ -62023,7 +62023,7 @@
 },
 {
 "id":"WP_049585862.1",
-"name":"G_TK37_RS01810",
+"name":"G_WP_049585862.1",
 "annotation":{
 "refseq":"WP_049585862.1",
 "sbo":"SBO:0000243"
@@ -62031,7 +62031,7 @@
 },
 {
 "id":"WP_049588748.1",
-"name":"G_TK37_RS17020",
+"name":"G_WP_049588748.1",
 "annotation":{
 "refseq":"WP_049588748.1",
 "sbo":"SBO:0000243"
@@ -62039,7 +62039,7 @@
 },
 {
 "id":"WP_049589098.1",
-"name":"G_TK37_RS19800",
+"name":"G_WP_049589098.1",
 "annotation":{
 "refseq":"WP_049589098.1",
 "sbo":"SBO:0000243"
@@ -62047,7 +62047,7 @@
 },
 {
 "id":"WP_012801201.1",
-"name":"G_TK37_RS04640",
+"name":"G_WP_012801201.1",
 "annotation":{
 "refseq":"WP_012801201.1",
 "sbo":"SBO:0000243"
@@ -62103,7 +62103,7 @@
 },
 {
 "id":"WP_049588780.1",
-"name":"G_TK37_RS17370",
+"name":"G_WP_049588780.1",
 "annotation":{
 "refseq":"WP_049588780.1",
 "sbo":"SBO:0000243"
@@ -62111,7 +62111,7 @@
 },
 {
 "id":"WP_049588870.1",
-"name":"G_TK37_RS18070",
+"name":"G_WP_049588870.1",
 "annotation":{
 "refseq":"WP_049588870.1",
 "sbo":"SBO:0000243"
@@ -62119,7 +62119,7 @@
 },
 {
 "id":"WP_049588741.1",
-"name":"G_TK37_RS16960",
+"name":"G_WP_049588741.1",
 "annotation":{
 "refseq":"WP_049588741.1",
 "sbo":"SBO:0000243"
@@ -62127,7 +62127,7 @@
 },
 {
 "id":"WP_049588210.1",
-"name":"G_TK37_RS13645",
+"name":"G_WP_049588210.1",
 "annotation":{
 "refseq":"WP_049588210.1",
 "sbo":"SBO:0000243"
@@ -62183,7 +62183,7 @@
 },
 {
 "id":"WP_014950712.1",
-"name":"G_TK37_RS16420",
+"name":"G_WP_014950712.1",
 "annotation":{
 "refseq":"WP_014950712.1",
 "sbo":"SBO:0000243"
@@ -62191,7 +62191,7 @@
 },
 {
 "id":"WP_014951244.1",
-"name":"G_TK37_RS00505",
+"name":"G_WP_014951244.1",
 "annotation":{
 "refseq":"WP_014951244.1",
 "sbo":"SBO:0000243"
@@ -62199,7 +62199,7 @@
 },
 {
 "id":"WP_014951245.1",
-"name":"G_TK37_RS00500",
+"name":"G_WP_014951245.1",
 "annotation":{
 "refseq":"WP_014951245.1",
 "sbo":"SBO:0000243"
@@ -62207,7 +62207,7 @@
 },
 {
 "id":"WP_049585562.1",
-"name":"G_TK37_RS00495",
+"name":"G_WP_049585562.1",
 "annotation":{
 "refseq":"WP_049585562.1",
 "sbo":"SBO:0000243"
@@ -62223,7 +62223,7 @@
 },
 {
 "id":"WP_049587837.1",
-"name":"G_TK37_RS12090",
+"name":"G_WP_049587837.1",
 "annotation":{
 "refseq":"WP_049587837.1",
 "sbo":"SBO:0000243"
@@ -62231,7 +62231,7 @@
 },
 {
 "id":"WP_049589016.1",
-"name":"G_TK37_RS19135",
+"name":"G_WP_049589016.1",
 "annotation":{
 "refseq":"WP_049589016.1",
 "sbo":"SBO:0000243"
@@ -62239,7 +62239,7 @@
 },
 {
 "id":"WP_049586648.1",
-"name":"G_TK37_RS06200",
+"name":"G_WP_049586648.1",
 "annotation":{
 "refseq":"WP_049586648.1",
 "sbo":"SBO:0000243"
@@ -62255,7 +62255,7 @@
 },
 {
 "id":"WP_049587602.1",
-"name":"G_TK37_RS11065",
+"name":"G_WP_049587602.1",
 "annotation":{
 "refseq":"WP_049587602.1",
 "sbo":"SBO:0000243"
@@ -62263,7 +62263,7 @@
 },
 {
 "id":"WP_049585972.1",
-"name":"G_TK37_RS02670",
+"name":"G_WP_049585972.1",
 "annotation":{
 "refseq":"WP_049585972.1",
 "sbo":"SBO:0000243"
@@ -62271,7 +62271,7 @@
 },
 {
 "id":"WP_049588979.1",
-"name":"G_TK37_RS18850",
+"name":"G_WP_049588979.1",
 "annotation":{
 "refseq":"WP_049588979.1",
 "sbo":"SBO:0000243"
@@ -62287,7 +62287,7 @@
 },
 {
 "id":"WP_049586976.1",
-"name":"G_TK37_RS08055",
+"name":"G_WP_049586976.1",
 "annotation":{
 "refseq":"WP_049586976.1",
 "sbo":"SBO:0000243"
@@ -62295,7 +62295,7 @@
 },
 {
 "id":"WP_049588150.1",
-"name":"G_TK37_RS13360",
+"name":"G_WP_049588150.1",
 "annotation":{
 "refseq":"WP_049588150.1",
 "sbo":"SBO:0000243"
@@ -62303,7 +62303,7 @@
 },
 {
 "id":"WP_014948838.1",
-"name":"G_TK37_RS01850",
+"name":"G_WP_014948838.1",
 "annotation":{
 "refseq":"WP_014948838.1",
 "sbo":"SBO:0000243"
@@ -62311,7 +62311,7 @@
 },
 {
 "id":"WP_014978802.1",
-"name":"G_TK37_RS02220",
+"name":"G_WP_014978802.1",
 "annotation":{
 "refseq":"WP_014978802.1",
 "sbo":"SBO:0000243"
@@ -62327,7 +62327,7 @@
 },
 {
 "id":"WP_049588028.1",
-"name":"G_TK37_RS12810",
+"name":"G_WP_049588028.1",
 "annotation":{
 "refseq":"WP_049588028.1",
 "sbo":"SBO:0000243"
@@ -62343,7 +62343,7 @@
 },
 {
 "id":"WP_049586605.1",
-"name":"G_TK37_RS06030",
+"name":"G_WP_049586605.1",
 "annotation":{
 "refseq":"WP_049586605.1",
 "sbo":"SBO:0000243"
@@ -62351,7 +62351,7 @@
 },
 {
 "id":"WP_049586436.1",
-"name":"G_TK37_RS05250",
+"name":"G_WP_049586436.1",
 "annotation":{
 "refseq":"WP_049586436.1",
 "sbo":"SBO:0000243"
@@ -62367,7 +62367,7 @@
 },
 {
 "id":"WP_049588126.1",
-"name":"G_TK37_RS13260",
+"name":"G_WP_049588126.1",
 "annotation":{
 "refseq":"WP_049588126.1",
 "sbo":"SBO:0000243"
@@ -62375,7 +62375,7 @@
 },
 {
 "id":"WP_049589081.1",
-"name":"G_TK37_RS19710",
+"name":"G_WP_049589081.1",
 "annotation":{
 "refseq":"WP_049589081.1",
 "sbo":"SBO:0000243"
@@ -62415,7 +62415,7 @@
 },
 {
 "id":"WP_049588567.1",
-"name":"G_TK37_RS15550",
+"name":"G_WP_049588567.1",
 "annotation":{
 "refseq":"WP_049588567.1",
 "sbo":"SBO:0000243"
@@ -62423,7 +62423,7 @@
 },
 {
 "id":"WP_049587592.1",
-"name":"G_TK37_RS11015",
+"name":"G_WP_049587592.1",
 "annotation":{
 "refseq":"WP_049587592.1",
 "sbo":"SBO:0000243"
@@ -62431,7 +62431,7 @@
 },
 {
 "id":"WP_049586025.1",
-"name":"G_TK37_RS03070",
+"name":"G_WP_049586025.1",
 "annotation":{
 "refseq":"WP_049586025.1",
 "sbo":"SBO:0000243"
@@ -62447,7 +62447,7 @@
 },
 {
 "id":"WP_049586907.1",
-"name":"G_TK37_RS07645",
+"name":"G_WP_049586907.1",
 "annotation":{
 "refseq":"WP_049586907.1",
 "sbo":"SBO:0000243"
@@ -62463,7 +62463,7 @@
 },
 {
 "id":"WP_014977961.1",
-"name":"G_TK37_RS08625",
+"name":"G_WP_014977961.1",
 "annotation":{
 "refseq":"WP_014977961.1",
 "sbo":"SBO:0000243"
@@ -62471,7 +62471,7 @@
 },
 {
 "id":"WP_049585878.1",
-"name":"G_TK37_RS02020",
+"name":"G_WP_049585878.1",
 "annotation":{
 "refseq":"WP_049585878.1",
 "sbo":"SBO:0000243"
@@ -62479,7 +62479,7 @@
 },
 {
 "id":"WP_152910898.1",
-"name":"G_TK37_RS15840",
+"name":"G_WP_152910898.1",
 "annotation":{
 "refseq":"WP_152910898.1",
 "sbo":"SBO:0000243"
@@ -62487,7 +62487,7 @@
 },
 {
 "id":"WP_049585810.1",
-"name":"G_TK37_RS01380",
+"name":"G_WP_049585810.1",
 "annotation":{
 "refseq":"WP_049585810.1",
 "sbo":"SBO:0000243"
@@ -62495,7 +62495,7 @@
 },
 {
 "id":"WP_014978293.1",
-"name":"G_TK37_RS08125",
+"name":"G_WP_014978293.1",
 "annotation":{
 "refseq":"WP_014978293.1",
 "sbo":"SBO:0000243"
@@ -62511,7 +62511,7 @@
 },
 {
 "id":"WP_049587064.1",
-"name":"G_TK37_RS08450",
+"name":"G_WP_049587064.1",
 "annotation":{
 "refseq":"WP_049587064.1",
 "sbo":"SBO:0000243"
@@ -62535,7 +62535,7 @@
 },
 {
 "id":"WP_049587537.1",
-"name":"G_TK37_RS10765",
+"name":"G_WP_049587537.1",
 "annotation":{
 "refseq":"WP_049587537.1",
 "sbo":"SBO:0000243"
@@ -62551,7 +62551,7 @@
 },
 {
 "id":"WP_049586061.1",
-"name":"G_TK37_RS03360",
+"name":"G_WP_049586061.1",
 "annotation":{
 "refseq":"WP_049586061.1",
 "sbo":"SBO:0000243"
@@ -62567,7 +62567,7 @@
 },
 {
 "id":"WP_014950659.1",
-"name":"G_TK37_RS13345",
+"name":"G_WP_014950659.1",
 "annotation":{
 "refseq":"WP_014950659.1",
 "sbo":"SBO:0000243"
@@ -62599,7 +62599,7 @@
 },
 {
 "id":"WP_049588920.1",
-"name":"G_TK37_RS18385",
+"name":"G_WP_049588920.1",
 "annotation":{
 "refseq":"WP_049588920.1",
 "sbo":"SBO:0000243"
@@ -62607,7 +62607,7 @@
 },
 {
 "id":"WP_039216382.1",
-"name":"G_TK37_RS07835",
+"name":"G_WP_039216382.1",
 "annotation":{
 "refseq":"WP_039216382.1",
 "sbo":"SBO:0000243"
@@ -62615,7 +62615,7 @@
 },
 {
 "id":"WP_049586874.1",
-"name":"G_TK37_RS07410",
+"name":"G_WP_049586874.1",
 "annotation":{
 "refseq":"WP_049586874.1",
 "sbo":"SBO:0000243"
@@ -62623,7 +62623,7 @@
 },
 {
 "id":"WP_049588329.1",
-"name":"G_TK37_RS14340",
+"name":"G_WP_049588329.1",
 "annotation":{
 "refseq":"WP_049588329.1",
 "sbo":"SBO:0000243"
@@ -62647,7 +62647,7 @@
 },
 {
 "id":"WP_049588847.1",
-"name":"G_TK37_RS17800",
+"name":"G_WP_049588847.1",
 "annotation":{
 "refseq":"WP_049588847.1",
 "sbo":"SBO:0000243"
@@ -62679,7 +62679,7 @@
 },
 {
 "id":"WP_049586106.1",
-"name":"G_TK37_RS03565",
+"name":"G_WP_049586106.1",
 "annotation":{
 "refseq":"WP_049586106.1",
 "sbo":"SBO:0000243"
@@ -62695,7 +62695,7 @@
 },
 {
 "id":"WP_080986455.1",
-"name":"G_TK37_RS15725",
+"name":"G_WP_080986455.1",
 "annotation":{
 "refseq":"WP_080986455.1",
 "sbo":"SBO:0000243"
@@ -62703,7 +62703,7 @@
 },
 {
 "id":"WP_049588128.1",
-"name":"G_TK37_RS13265",
+"name":"G_WP_049588128.1",
 "annotation":{
 "refseq":"WP_049588128.1",
 "sbo":"SBO:0000243"
@@ -62711,7 +62711,7 @@
 },
 {
 "id":"WP_039229394.1",
-"name":"G_TK37_RS11960",
+"name":"G_WP_039229394.1",
 "annotation":{
 "refseq":"WP_039229394.1",
 "sbo":"SBO:0000243"
@@ -62719,7 +62719,7 @@
 },
 {
 "id":"WP_049588830.1",
-"name":"G_TK37_RS17695",
+"name":"G_WP_049588830.1",
 "annotation":{
 "refseq":"WP_049588830.1",
 "sbo":"SBO:0000243"
@@ -62743,7 +62743,7 @@
 },
 {
 "id":"WP_014950084.1",
-"name":"G_TK37_RS06035",
+"name":"G_WP_014950084.1",
 "annotation":{
 "refseq":"WP_014950084.1",
 "sbo":"SBO:0000243"
@@ -62751,7 +62751,7 @@
 },
 {
 "id":"WP_049588138.1",
-"name":"G_TK37_RS13185",
+"name":"G_WP_049588138.1",
 "annotation":{
 "refseq":"WP_049588138.1",
 "sbo":"SBO:0000243"
@@ -62759,7 +62759,7 @@
 },
 {
 "id":"WP_049585906.1",
-"name":"G_TK37_RS02210",
+"name":"G_WP_049585906.1",
 "annotation":{
 "refseq":"WP_049585906.1",
 "sbo":"SBO:0000243"
@@ -62791,7 +62791,7 @@
 },
 {
 "id":"WP_049589083.1",
-"name":"G_TK37_RS19715",
+"name":"G_WP_049589083.1",
 "annotation":{
 "refseq":"WP_049589083.1",
 "sbo":"SBO:0000243"
@@ -62799,7 +62799,7 @@
 },
 {
 "id":"WP_049588772.1",
-"name":"G_TK37_RS17295",
+"name":"G_WP_049588772.1",
 "annotation":{
 "refseq":"WP_049588772.1",
 "sbo":"SBO:0000243"
@@ -62815,7 +62815,7 @@
 },
 {
 "id":"WP_014950103.1",
-"name":"G_TK37_RS05930",
+"name":"G_WP_014950103.1",
 "annotation":{
 "refseq":"WP_014950103.1",
 "sbo":"SBO:0000243"
@@ -62879,7 +62879,7 @@
 },
 {
 "id":"WP_049589197.1",
-"name":"G_TK37_RS20290",
+"name":"G_WP_049589197.1",
 "annotation":{
 "refseq":"WP_049589197.1",
 "sbo":"SBO:0000243"
@@ -62887,7 +62887,7 @@
 },
 {
 "id":"WP_049587049.1",
-"name":"G_TK37_RS08330",
+"name":"G_WP_049587049.1",
 "annotation":{
 "refseq":"WP_049587049.1",
 "sbo":"SBO:0000243"
@@ -62903,7 +62903,7 @@
 },
 {
 "id":"WP_049588345.1",
-"name":"G_TK37_RS14420",
+"name":"G_WP_049588345.1",
 "annotation":{
 "refseq":"WP_049588345.1",
 "sbo":"SBO:0000243"
@@ -62911,7 +62911,7 @@
 },
 {
 "id":"WP_049587223.1",
-"name":"G_TK37_RS09215",
+"name":"G_WP_049587223.1",
 "annotation":{
 "refseq":"WP_049587223.1",
 "sbo":"SBO:0000243"
@@ -62927,7 +62927,7 @@
 },
 {
 "id":"WP_014949444.1",
-"name":"G_TK37_RS15995",
+"name":"G_WP_014949444.1",
 "annotation":{
 "refseq":"WP_014949444.1",
 "sbo":"SBO:0000243"
@@ -62951,15 +62951,15 @@
 },
 {
 "id":"WP_049587909.1",
-"name":"G_TK37_RS12355",
+"name":"G_WP_049587909.1",
 "annotation":{
 "refseq":"WP_049587909.1",
 "sbo":"SBO:0000243"
 }
 },
 {
-"id":"TK37_RS17565",
-"name":"G_TK37_RS17565",
+"id":"WP_049588809.1",
+"name":"G_WP_049588809.1",
 "annotation":{
 "refseq":"WP_049588809.1",
 "sbo":"SBO:0000243"
@@ -62975,7 +62975,7 @@
 },
 {
 "id":"WP_049587746.1",
-"name":"G_TK37_RS11755",
+"name":"G_WP_049587746.1",
 "annotation":{
 "refseq":"WP_049587746.1",
 "sbo":"SBO:0000243"
@@ -62983,7 +62983,7 @@
 },
 {
 "id":"WP_049585903.1",
-"name":"G_TK37_RS02185",
+"name":"G_WP_049585903.1",
 "annotation":{
 "refseq":"WP_049585903.1",
 "sbo":"SBO:0000243"
@@ -62991,7 +62991,7 @@
 },
 {
 "id":"WP_049585722.1",
-"name":"G_TK37_RS01140",
+"name":"G_WP_049585722.1",
 "annotation":{
 "refseq":"WP_049585722.1",
 "sbo":"SBO:0000243"
@@ -63007,7 +63007,7 @@
 },
 {
 "id":"WP_014949914.1",
-"name":"G_TK37_RS07485",
+"name":"G_WP_014949914.1",
 "annotation":{
 "refseq":"WP_014949914.1",
 "sbo":"SBO:0000243"
@@ -63015,7 +63015,7 @@
 },
 {
 "id":"WP_049586645.1",
-"name":"G_TK37_RS06190",
+"name":"G_WP_049586645.1",
 "annotation":{
 "refseq":"WP_049586645.1",
 "sbo":"SBO:0000243"
@@ -63023,7 +63023,7 @@
 },
 {
 "id":"WP_049588766.1",
-"name":"G_TK37_RS17240",
+"name":"G_WP_049588766.1",
 "annotation":{
 "refseq":"WP_049588766.1",
 "sbo":"SBO:0000243"
@@ -63031,7 +63031,7 @@
 },
 {
 "id":"WP_049588948.1",
-"name":"G_TK37_RS18625",
+"name":"G_WP_049588948.1",
 "annotation":{
 "refseq":"WP_049588948.1",
 "sbo":"SBO:0000243"
@@ -63039,7 +63039,7 @@
 },
 {
 "id":"WP_049588845.1",
-"name":"G_TK37_RS17790",
+"name":"G_WP_049588845.1",
 "annotation":{
 "refseq":"WP_049588845.1",
 "sbo":"SBO:0000243"
@@ -63055,7 +63055,7 @@
 },
 {
 "id":"WP_014949662.1",
-"name":"G_TK37_RS16225",
+"name":"G_WP_014949662.1",
 "annotation":{
 "refseq":"WP_014949662.1",
 "sbo":"SBO:0000243"
@@ -63071,7 +63071,7 @@
 },
 {
 "id":"WP_014979808.1",
-"name":"G_TK37_RS05740",
+"name":"G_WP_014979808.1",
 "annotation":{
 "refseq":"WP_014979808.1",
 "sbo":"SBO:0000243"
@@ -63087,7 +63087,7 @@
 },
 {
 "id":"WP_049588997.1",
-"name":"G_TK37_RS18950",
+"name":"G_WP_049588997.1",
 "annotation":{
 "refseq":"WP_049588997.1",
 "sbo":"SBO:0000243"
@@ -63103,7 +63103,7 @@
 },
 {
 "id":"WP_014950719.1",
-"name":"G_TK37_RS16455",
+"name":"G_WP_014950719.1",
 "annotation":{
 "refseq":"WP_014950719.1",
 "sbo":"SBO:0000243"
@@ -63111,7 +63111,7 @@
 },
 {
 "id":"WP_049585746.1",
-"name":"G_TK37_RS00345",
+"name":"G_WP_049585746.1",
 "annotation":{
 "refseq":"WP_049585746.1",
 "sbo":"SBO:0000243"
@@ -63119,7 +63119,7 @@
 },
 {
 "id":"WP_049587867.1",
-"name":"G_TK37_RS12220",
+"name":"G_WP_049587867.1",
 "annotation":{
 "refseq":"WP_049587867.1",
 "sbo":"SBO:0000243"
@@ -63127,7 +63127,7 @@
 },
 {
 "id":"WP_049588244.1",
-"name":"G_TK37_RS13895",
+"name":"G_WP_049588244.1",
 "annotation":{
 "refseq":"WP_049588244.1",
 "sbo":"SBO:0000243"
@@ -63135,7 +63135,7 @@
 },
 {
 "id":"WP_049587283.1",
-"name":"G_TK37_RS09460",
+"name":"G_WP_049587283.1",
 "annotation":{
 "refseq":"WP_049587283.1",
 "sbo":"SBO:0000243"
@@ -63143,7 +63143,7 @@
 },
 {
 "id":"WP_049587281.1",
-"name":"G_TK37_RS09455",
+"name":"G_WP_049587281.1",
 "annotation":{
 "refseq":"WP_049587281.1",
 "sbo":"SBO:0000243"
@@ -63151,7 +63151,7 @@
 },
 {
 "id":"WP_049588770.1",
-"name":"G_TK37_RS17270",
+"name":"G_WP_049588770.1",
 "annotation":{
 "refseq":"WP_049588770.1",
 "sbo":"SBO:0000243"
@@ -63167,7 +63167,7 @@
 },
 {
 "id":"WP_049587680.1",
-"name":"G_TK37_RS11450",
+"name":"G_WP_049587680.1",
 "annotation":{
 "refseq":"WP_049587680.1",
 "sbo":"SBO:0000243"
@@ -63175,7 +63175,7 @@
 },
 {
 "id":"WP_049585717.1",
-"name":"G_TK37_RS01120",
+"name":"G_WP_049585717.1",
 "annotation":{
 "refseq":"WP_049585717.1",
 "sbo":"SBO:0000243"
@@ -63191,7 +63191,7 @@
 },
 {
 "id":"WP_049588396.1",
-"name":"G_TK37_RS14645",
+"name":"G_WP_049588396.1",
 "annotation":{
 "refseq":"WP_049588396.1",
 "sbo":"SBO:0000243"
@@ -63199,7 +63199,7 @@
 },
 {
 "id":"WP_049585600.1",
-"name":"G_TK37_RS00650",
+"name":"G_WP_049585600.1",
 "annotation":{
 "refseq":"WP_049585600.1",
 "sbo":"SBO:0000243"
@@ -63215,7 +63215,7 @@
 },
 {
 "id":"WP_014977894.1",
-"name":"G_TK37_RS10760",
+"name":"G_WP_014977894.1",
 "annotation":{
 "refseq":"WP_014977894.1",
 "sbo":"SBO:0000243"
@@ -63231,7 +63231,7 @@
 },
 {
 "id":"WP_014948051.1",
-"name":"G_TK37_RS14335",
+"name":"G_WP_014948051.1",
 "annotation":{
 "refseq":"WP_014948051.1",
 "sbo":"SBO:0000243"
@@ -63247,7 +63247,7 @@
 },
 {
 "id":"WP_049588586.1",
-"name":"G_TK37_RS15730",
+"name":"G_WP_049588586.1",
 "annotation":{
 "refseq":"WP_049588586.1",
 "sbo":"SBO:0000243"
@@ -63255,7 +63255,7 @@
 },
 {
 "id":"WP_039227619.1",
-"name":"G_TK37_RS18050",
+"name":"G_WP_039227619.1",
 "annotation":{
 "refseq":"WP_039227619.1",
 "sbo":"SBO:0000243"
@@ -63287,7 +63287,7 @@
 },
 {
 "id":"WP_014948183.1",
-"name":"G_TK37_RS09700",
+"name":"G_WP_014948183.1",
 "annotation":{
 "refseq":"WP_014948183.1",
 "sbo":"SBO:0000243"
@@ -63295,7 +63295,7 @@
 },
 {
 "id":"WP_049587987.1",
-"name":"G_TK37_RS12590",
+"name":"G_WP_049587987.1",
 "annotation":{
 "refseq":"WP_049587987.1",
 "sbo":"SBO:0000243"
@@ -63311,7 +63311,7 @@
 },
 {
 "id":"WP_049587770.1",
-"name":"G_TK37_RS11860",
+"name":"G_WP_049587770.1",
 "annotation":{
 "refseq":"WP_049587770.1",
 "sbo":"SBO:0000243"
@@ -63335,7 +63335,7 @@
 },
 {
 "id":"WP_049588633.1",
-"name":"G_TK37_RS16050",
+"name":"G_WP_049588633.1",
 "annotation":{
 "refseq":"WP_049588633.1",
 "sbo":"SBO:0000243"
@@ -63351,7 +63351,7 @@
 },
 {
 "id":"WP_049587565.1",
-"name":"G_TK37_RS10910",
+"name":"G_WP_049587565.1",
 "annotation":{
 "refseq":"WP_049587565.1",
 "sbo":"SBO:0000243"
@@ -63359,7 +63359,7 @@
 },
 {
 "id":"WP_049588867.1",
-"name":"G_TK37_RS18055",
+"name":"G_WP_049588867.1",
 "annotation":{
 "refseq":"WP_049588867.1",
 "sbo":"SBO:0000243"
@@ -63367,7 +63367,7 @@
 },
 {
 "id":"WP_049587568.1",
-"name":"G_TK37_RS10920",
+"name":"G_WP_049587568.1",
 "annotation":{
 "refseq":"WP_049587568.1",
 "sbo":"SBO:0000243"
@@ -63375,7 +63375,7 @@
 },
 {
 "id":"WP_049588465.1",
-"name":"G_TK37_RS14945",
+"name":"G_WP_049588465.1",
 "annotation":{
 "refseq":"WP_049588465.1",
 "sbo":"SBO:0000243"
@@ -63383,7 +63383,7 @@
 },
 {
 "id":"WP_049588597.1",
-"name":"G_TK37_RS15790",
+"name":"G_WP_049588597.1",
 "annotation":{
 "refseq":"WP_049588597.1",
 "sbo":"SBO:0000243"
@@ -63391,7 +63391,7 @@
 },
 {
 "id":"WP_049588594.1",
-"name":"G_TK37_RS15775",
+"name":"G_WP_049588594.1",
 "annotation":{
 "refseq":"WP_049588594.1",
 "sbo":"SBO:0000243"
@@ -63399,7 +63399,7 @@
 },
 {
 "id":"WP_049588596.1",
-"name":"G_TK37_RS15785",
+"name":"G_WP_049588596.1",
 "annotation":{
 "refseq":"WP_049588596.1",
 "sbo":"SBO:0000243"
@@ -63407,7 +63407,7 @@
 },
 {
 "id":"WP_049588599.1",
-"name":"G_TK37_RS15800",
+"name":"G_WP_049588599.1",
 "annotation":{
 "refseq":"WP_049588599.1",
 "sbo":"SBO:0000243"
@@ -63415,7 +63415,7 @@
 },
 {
 "id":"WP_049588595.1",
-"name":"G_TK37_RS15780",
+"name":"G_WP_049588595.1",
 "annotation":{
 "refseq":"WP_049588595.1",
 "sbo":"SBO:0000243"
@@ -63423,7 +63423,7 @@
 },
 {
 "id":"WP_049588598.1",
-"name":"G_TK37_RS15795",
+"name":"G_WP_049588598.1",
 "annotation":{
 "refseq":"WP_049588598.1",
 "sbo":"SBO:0000243"
@@ -63431,7 +63431,7 @@
 },
 {
 "id":"WP_049586998.1",
-"name":"G_TK37_RS08145",
+"name":"G_WP_049586998.1",
 "annotation":{
 "refseq":"WP_049586998.1",
 "sbo":"SBO:0000243"
@@ -63471,7 +63471,7 @@
 },
 {
 "id":"WP_049585639.1",
-"name":"G_TK37_RS00790",
+"name":"G_WP_049585639.1",
 "annotation":{
 "refseq":"WP_049585639.1",
 "sbo":"SBO:0000243"
@@ -63487,7 +63487,7 @@
 },
 {
 "id":"WP_049586745.1",
-"name":"G_TK37_RS06765",
+"name":"G_WP_049586745.1",
 "annotation":{
 "refseq":"WP_049586745.1",
 "sbo":"SBO:0000243"
@@ -63495,7 +63495,7 @@
 },
 {
 "id":"WP_049586746.1",
-"name":"G_TK37_RS06770",
+"name":"G_WP_049586746.1",
 "annotation":{
 "refseq":"WP_049586746.1",
 "sbo":"SBO:0000243"
@@ -63503,7 +63503,7 @@
 },
 {
 "id":"WP_014949591.1",
-"name":"G_TK37_RS13675",
+"name":"G_WP_014949591.1",
 "annotation":{
 "refseq":"WP_014949591.1",
 "sbo":"SBO:0000243"
@@ -63559,7 +63559,7 @@
 },
 {
 "id":"WP_049588823.1",
-"name":"G_TK37_RS17635",
+"name":"G_WP_049588823.1",
 "annotation":{
 "refseq":"WP_049588823.1",
 "sbo":"SBO:0000243"
@@ -63631,7 +63631,7 @@
 },
 {
 "id":"WP_014977839.1",
-"name":"G_TK37_RS04925",
+"name":"G_WP_014977839.1",
 "annotation":{
 "refseq":"WP_014977839.1",
 "sbo":"SBO:0000243"
@@ -63639,7 +63639,7 @@
 },
 {
 "id":"WP_012516857.1",
-"name":"G_TK37_RS10495",
+"name":"G_WP_012516857.1",
 "annotation":{
 "refseq":"WP_012516857.1",
 "sbo":"SBO:0000243"
@@ -63647,7 +63647,7 @@
 },
 {
 "id":"WP_049587488.1",
-"name":"G_TK37_RS10490",
+"name":"G_WP_049587488.1",
 "annotation":{
 "refseq":"WP_049587488.1",
 "sbo":"SBO:0000243"
@@ -63655,7 +63655,7 @@
 },
 {
 "id":"WP_049586160.1",
-"name":"G_TK37_RS03825",
+"name":"G_WP_049586160.1",
 "annotation":{
 "refseq":"WP_049586160.1",
 "sbo":"SBO:0000243"
@@ -63703,7 +63703,7 @@
 },
 {
 "id":"WP_014951383.1",
-"name":"G_TK37_RS14925",
+"name":"G_WP_014951383.1",
 "annotation":{
 "refseq":"WP_014951383.1",
 "sbo":"SBO:0000243"
@@ -63719,7 +63719,7 @@
 },
 {
 "id":"WP_049587246.1",
-"name":"G_TK37_RS09305",
+"name":"G_WP_049587246.1",
 "annotation":{
 "refseq":"WP_049587246.1",
 "sbo":"SBO:0000243"
@@ -63727,7 +63727,7 @@
 },
 {
 "id":"WP_049587243.1",
-"name":"G_TK37_RS09285",
+"name":"G_WP_049587243.1",
 "annotation":{
 "refseq":"WP_049587243.1",
 "sbo":"SBO:0000243"
@@ -63735,7 +63735,7 @@
 },
 {
 "id":"WP_049588869.1",
-"name":"G_TK37_RS18065",
+"name":"G_WP_049588869.1",
 "annotation":{
 "refseq":"WP_049588869.1",
 "sbo":"SBO:0000243"
@@ -63743,7 +63743,7 @@
 },
 {
 "id":"WP_049589095.1",
-"name":"G_TK37_RS19790",
+"name":"G_WP_049589095.1",
 "annotation":{
 "refseq":"WP_049589095.1",
 "sbo":"SBO:0000243"
@@ -63751,7 +63751,7 @@
 },
 {
 "id":"WP_014977890.1",
-"name":"G_TK37_RS10740",
+"name":"G_WP_014977890.1",
 "annotation":{
 "refseq":"WP_014977890.1",
 "sbo":"SBO:0000243"
@@ -63767,7 +63767,7 @@
 },
 {
 "id":"WP_049585904.1",
-"name":"G_TK37_RS02190",
+"name":"G_WP_049585904.1",
 "annotation":{
 "refseq":"WP_049585904.1",
 "sbo":"SBO:0000243"
@@ -63775,7 +63775,7 @@
 },
 {
 "id":"WP_014947858.1",
-"name":"G_TK37_RS08540",
+"name":"G_WP_014947858.1",
 "annotation":{
 "refseq":"WP_014947858.1",
 "sbo":"SBO:0000243"
@@ -63831,7 +63831,7 @@
 },
 {
 "id":"WP_049586104.1",
-"name":"G_TK37_RS03560",
+"name":"G_WP_049586104.1",
 "annotation":{
 "refseq":"WP_049586104.1",
 "sbo":"SBO:0000243"
@@ -63847,7 +63847,7 @@
 },
 {
 "id":"WP_014998704.1",
-"name":"G_TK37_RS11075",
+"name":"G_WP_014998704.1",
 "annotation":{
 "refseq":"WP_014998704.1",
 "sbo":"SBO:0000243"
@@ -63855,7 +63855,7 @@
 },
 {
 "id":"WP_049588135.1",
-"name":"G_TK37_RS13320",
+"name":"G_WP_049588135.1",
 "annotation":{
 "refseq":"WP_049588135.1",
 "sbo":"SBO:0000243"
@@ -63863,7 +63863,7 @@
 },
 {
 "id":"WP_049586122.1",
-"name":"G_TK37_RS03610",
+"name":"G_WP_049586122.1",
 "annotation":{
 "refseq":"WP_049586122.1",
 "sbo":"SBO:0000243"
@@ -63879,7 +63879,7 @@
 },
 {
 "id":"WP_049587193.1",
-"name":"G_TK37_RS09110",
+"name":"G_WP_049587193.1",
 "annotation":{
 "refseq":"WP_049587193.1",
 "sbo":"SBO:0000243"
@@ -63887,7 +63887,7 @@
 },
 {
 "id":"WP_049587198.1",
-"name":"G_TK37_RS09130",
+"name":"G_WP_049587198.1",
 "annotation":{
 "refseq":"WP_049587198.1",
 "sbo":"SBO:0000243"
@@ -63911,7 +63911,7 @@
 },
 {
 "id":"WP_049586240.1",
-"name":"G_TK37_RS04280",
+"name":"G_WP_049586240.1",
 "annotation":{
 "refseq":"WP_049586240.1",
 "sbo":"SBO:0000243"
@@ -63919,7 +63919,7 @@
 },
 {
 "id":"WP_080986407.1",
-"name":"G_TK37_RS09180",
+"name":"G_WP_080986407.1",
 "annotation":{
 "refseq":"WP_080986407.1",
 "sbo":"SBO:0000243"
@@ -63927,7 +63927,7 @@
 },
 {
 "id":"WP_039216400.1",
-"name":"G_TK37_RS08000",
+"name":"G_WP_039216400.1",
 "annotation":{
 "refseq":"WP_039216400.1",
 "sbo":"SBO:0000243"
@@ -63935,7 +63935,7 @@
 },
 {
 "id":"WP_049587081.1",
-"name":"G_TK37_RS08515",
+"name":"G_WP_049587081.1",
 "annotation":{
 "refseq":"WP_049587081.1",
 "sbo":"SBO:0000243"
@@ -63943,7 +63943,7 @@
 },
 {
 "id":"WP_014950514.1",
-"name":"G_TK37_RS19575",
+"name":"G_WP_014950514.1",
 "annotation":{
 "refseq":"WP_014950514.1",
 "sbo":"SBO:0000243"
@@ -63959,7 +63959,7 @@
 },
 {
 "id":"WP_049586946.1",
-"name":"G_TK37_RS07785",
+"name":"G_WP_049586946.1",
 "annotation":{
 "refseq":"WP_049586946.1",
 "sbo":"SBO:0000243"
@@ -63967,7 +63967,7 @@
 },
 {
 "id":"WP_049585524.1",
-"name":"G_TK37_RS00415",
+"name":"G_WP_049585524.1",
 "annotation":{
 "refseq":"WP_049585524.1",
 "sbo":"SBO:0000243"
@@ -63975,7 +63975,7 @@
 },
 {
 "id":"WP_049588447.1",
-"name":"G_TK37_RS14950",
+"name":"G_WP_049588447.1",
 "annotation":{
 "refseq":"WP_049588447.1",
 "sbo":"SBO:0000243"
@@ -63991,7 +63991,7 @@
 },
 {
 "id":"WP_049585802.1",
-"name":"G_TK37_RS01355",
+"name":"G_WP_049585802.1",
 "annotation":{
 "refseq":"WP_049585802.1",
 "sbo":"SBO:0000243"
@@ -63999,7 +63999,7 @@
 },
 {
 "id":"WP_049587489.1",
-"name":"G_TK37_RS10525",
+"name":"G_WP_049587489.1",
 "annotation":{
 "refseq":"WP_049587489.1",
 "sbo":"SBO:0000243"
@@ -64007,7 +64007,7 @@
 },
 {
 "id":"WP_049588525.1",
-"name":"G_TK37_RS15275",
+"name":"G_WP_049588525.1",
 "annotation":{
 "refseq":"WP_049588525.1",
 "sbo":"SBO:0000243"
@@ -64015,7 +64015,7 @@
 },
 {
 "id":"WP_049588017.1",
-"name":"G_TK37_RS12750",
+"name":"G_WP_049588017.1",
 "annotation":{
 "refseq":"WP_049588017.1",
 "sbo":"SBO:0000243"
@@ -64023,7 +64023,7 @@
 },
 {
 "id":"WP_049588019.1",
-"name":"G_TK37_RS12770",
+"name":"G_WP_049588019.1",
 "annotation":{
 "refseq":"WP_049588019.1",
 "sbo":"SBO:0000243"
@@ -64059,11 +64059,11 @@
 },
 {
 "id":"WP_049587566.1",
-"name":"G_TK37_RS10915"
+"name":"G_WP_049587566.1"
 },
 {
 "id":"WP_049586595.1",
-"name":"G_TK37_RS05910"
+"name":"G_WP_049586595.1"
 },
 {
 "id":"WP_049588093.1",
@@ -64075,11 +64075,11 @@
 },
 {
 "id":"WP_014948070.1",
-"name":"G_TK37_RS14240"
+"name":"G_WP_014948070.1"
 },
 {
 "id":"WP_049588222.1",
-"name":"G_TK37_RS13750"
+"name":"G_WP_049588222.1"
 }
 ],
 "id":"iHS4156",

--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #223** (CUSTOM-CI)
+- **PR #226** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

So it turns out that editing the IDs of the gene objects in the model in #223 did not edit the GPRs of any reactions, so all of the re-identified genes wound up associated with zero reactions, and Cobrapy automatically created new gene objects using the old locus tag IDs to associate with all reactions, and it's just a huge mess. In this PR, I took the `model.json` file from before #223 was merged and edited it directly to replace all instances of each locus tag with the corresponding RefSeq protein accession, and that seems to have actually worked.

**I hereby confirm that I have:**
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists