### PR TITLE
Resolve duplicate allysine/2-aminoadipate-6-semialdehyde metabolites

### DIFF
--- a/model.json
+++ b/model.json
@@ -18262,26 +18262,6 @@
 }
 },
 {
-"id":"cpd01046_c0",
-"name":"Allysine (cpd01046_c0)",
-"compartment":"c0",
-"charge":0,
-"formula":"C6H11NO3",
-"annotation":{
-"bigg.metabolite":"L2aadp6sa",
-"biocyc":"META:ALLYSINE",
-"inchi":"InChI=1S/C6H11NO3/c7-5(6(9)10)3-1-2-4-8/h4-5H,1-3,7H2,(H,9,10)/t5-/m0/s1",
-"inchikey":"GFXYTQPNNXGICT-YFKPBYRVSA-N",
-"kegg.compound":"C04076",
-"metanetx.chemical":[
-"MNXM219",
-"MNXM89905"
-],
-"sbo":"SBO:0000247",
-"seed.compound":"cpd01046"
-}
-},
-{
 "id":"cpd01042_c0",
 "name":"p-Cresol (cpd01042_c0)",
 "compartment":"c0",
@@ -52247,7 +52227,7 @@
 "cpd00039_c0":-1.0,
 "cpd00764_c0":1.0,
 "cpd00800_c0":-1.0,
-"cpd01046_c0":1.0
+"cpd02522_c0":1.0
 },
 "lower_bound":-1000.0,
 "upper_bound":1000.0,

--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #223** (CUSTOM-CI)
+- **PR #228** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request

- Replaces cpd01045_c0 with cpd02522_c0 in rxn40439_c0
- Removes cpd01045_c0 from the model

cpd01045_c0 ("allysine") and cpd02522_c0 ("2-aminoadipate-6-semialdehyde") are duplicates -- those are two different names for the same real-life compound. cpd01045_c0 currently only participates in rxn40439_c0, while cpd02522_c0 participates in both rxn01662_c0 and rxn01664_c0 (which I added in #216), so I'm keeping cpd02522 and removing cpd01045_c0. I noticed this when I realized that #225 would have added rxn00309, which used cpd01045, and rxn00317, which used cpd02522 (I have already edited #225 so that rxn00309 uses cpd02522 instead of cpd01045).

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [x] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
