### PR TITLE
Fix: improve GPRs of acyl-CoA synthetase reactions

### DIFF
--- a/model.json
+++ b/model.json
@@ -21245,7 +21245,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
+"gene_reaction_rule":"WP_049587062.1 or WP_049587639.1 or WP_014950005.1 or WP_049586144.1 or WP_049588937.1",
 "annotation":{
 "ec-code":"6.2.1.3",
 "metanetx.reaction":"MNXR134818",
@@ -26964,7 +26964,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
+"gene_reaction_rule":"WP_049587062.1 or WP_049587639.1 or WP_014950005.1 or WP_049586144.1 or WP_049588937.1",
 "annotation":{
 "ec-code":"6.2.1.3",
 "metanetx.reaction":"MNXR134816",
@@ -33166,7 +33166,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
+"gene_reaction_rule":"WP_049587062.1 or WP_049587639.1 or WP_014950005.1 or WP_049586144.1 or WP_049588937.1",
 "annotation":{
 "ec-code":"6.2.1.3",
 "metanetx.reaction":"MNXR134819",
@@ -36301,7 +36301,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
+"gene_reaction_rule":"WP_049587062.1 or WP_049587639.1 or WP_014950005.1 or WP_049586144.1 or WP_049588937.1",
 "annotation":{
 "bigg.reaction":[
 "FACOAL161p",
@@ -39057,7 +39057,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
+"gene_reaction_rule":"WP_049587062.1 or WP_049587639.1 or WP_014950005.1 or WP_049586144.1 or WP_049588937.1",
 "annotation":{
 "bigg.reaction":[
 "FACOAL160",
@@ -39373,7 +39373,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
+"gene_reaction_rule":"WP_049587062.1 or WP_049587639.1 or WP_014950005.1 or WP_049586144.1 or WP_049588937.1",
 "annotation":{
 "bigg.reaction":"ACAC",
 "biocyc":"META:ACETOACETATE--COA-LIGASE-RXN",
@@ -41790,7 +41790,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
+"gene_reaction_rule":"WP_049587062.1 or WP_049587639.1 or WP_014950005.1 or WP_049586144.1 or WP_049588937.1",
 "annotation":{
 "ec-code":"6.2.1.3",
 "metanetx.reaction":"MNXR134815",
@@ -44264,7 +44264,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
+"gene_reaction_rule":"WP_049587062.1 or WP_049587639.1 or WP_014950005.1 or WP_049586144.1 or WP_049588937.1",
 "annotation":{
 "ec-code":"6.2.1.3",
 "metanetx.reaction":"MNXR134820",
@@ -45151,7 +45151,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
+"gene_reaction_rule":"WP_049587062.1 or WP_049587639.1 or WP_014950005.1 or WP_049586144.1 or WP_049588937.1",
 "annotation":{
 "bigg.reaction":"FACOAL180",
 "biocyc":[
@@ -45465,7 +45465,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
+"gene_reaction_rule":"WP_049587062.1 or WP_049587639.1 or WP_014950005.1 or WP_049586144.1 or WP_049588937.1",
 "annotation":{
 "ec-code":"6.2.1.3",
 "metanetx.reaction":"MNXR134817",
@@ -51148,7 +51148,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
+"gene_reaction_rule":"WP_049587062.1 or WP_049587639.1 or WP_014950005.1 or WP_049586144.1 or WP_049588937.1",
 "annotation":{
 "bigg.reaction":"FACOAL181",
 "metanetx.reaction":"MNXR136033",
@@ -51846,7 +51846,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1",
+"gene_reaction_rule":"WP_049587062.1 or WP_049587639.1 or WP_014950005.1 or WP_049586144.1 or WP_049588937.1",
 "annotation":{
 "bigg.reaction":[
 "FACOAL140",

--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #230** (CUSTOM-CI)
+- **PR #238** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request changes the GPRs of `rxn00947_c0`, `rxn00988_c0`, `rxn05247_c0`, `rxn05248_c0`, `rxn05249_c0`, `rxn05250_c0`, `rxn05251_c0`, `rxn05252_c0`, `rxn05736_c0`, `rxn09448_c0`, `rxn09449_c0`, and `rxn09450_c0` from
`WP_049587062.1 and WP_049587639.1 and WP_014950005.1 and WP_049586144.1 and WP_049588937.1`
to
`WP_049587062.1 or WP_049587639.1 or WP_014950005.1 or WP_049586144.1 or WP_049588937.1`
and makes no other changes to the model.

All of the reactions mentioned above currently have exactly the same GPR, and all of the genes in that GPR are annotated as acyl-CoA synthetases, sometimes specifically long-chain acyl-CoA synthetases and/or fadD (E.C. number [6.2.1.3](https://www.genome.jp/entry/6.2.1.3)). As far as I can tell, bacterial acyl-CoA synthetases are not known to be enzyme complexes, and several bacteria are known to posses multiple acyl-CoA synthetases, which are expressed under different conditions or have different substrate specificities ([source](https://doi.org/10.1007/978-3-319-50418-6_42)). So I am replacing all of the “and”s in these GPRs with “or”s so that these genes are treated as independently functional isozymes and not codependent subunits of a single enzyme complex. As with #236, I came across these while looking for reactions with suspiciously many genes ANDed together in an effort to improve the accuracy of the model’s gene essentiality predictions.

For reference:

- `rxn00947_c0`: ATP + CoA + Hexadecanoate --> PPi + AMP + H+ + Hexadecanoyl-CoA
- `rxn00988_c0`: ATP + CoA + Acetoacetate --> PPi + AMP + H+ + Acetoacetyl-CoA
- `rxn05247_c0`: ATP + CoA + fa1 --> PPi + AMP + 12-Methyltridecanoyl-CoA
- `rxn05248_c0`: ATP + CoA + fa4 --> PPi + AMP + 12-Methyltetradecanoyl-CoA
- `rxn05249_c0`: ATP + CoA + fa3 --> PPi + AMP + 13-Methyltetradecanoyl-CoA
- `rxn05250_c0`: ATP + CoA + fa6 --> PPi + AMP + 14-Methylpentadecanoyl-CoA
- `rxn05251_c0`: ATP + CoA + fa12 --> PPi + AMP + 14-Methylhexadecanoyl-CoA
- `rxn05252_c0`: ATP + CoA + fa11 --> PPi + AMP + 15-Methylhexadecanoyl-CoA
- `rxn05736_c0`: ATP + CoA + Tetradecanoate --> PPi + AMP + H+ + Tetradecanoyl-CoA
- `rxn09448_c0`: ATP + CoA + (11Z)-Octadecenoate --> PPi + AMP + Octadecenoyl-CoA
- `rxn09449_c0`: ATP + CoA + Octadecanoate --> PPi + AMP + H+ + Octadecanoyl-CoA
- `rxn09450_c0`: ATP + CoA + (9Z)-Hexadecenoate --> PPi + AMP + Hexadecenoyl-CoA

**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists