### PR TITLE
Fix: GPR of rxn00006_c0 (catalase)

### DIFF
--- a/model.json
+++ b/model.json
@@ -34277,7 +34277,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"(WP_049588336.1 and WP_039225577.1 and WP_152910875.1 and WP_049586869.1) or WP_049586869.1 or (WP_049588336.1 and WP_152910875.1 and WP_039225577.1) or WP_014977393.1",
+"gene_reaction_rule":"WP_049588336.1 or WP_039225577.1 or WP_152910875.1 or WP_049586869.1 or WP_014977393.1",
 "annotation":{
 "bigg.reaction":[
 "CAT",
@@ -60175,7 +60175,7 @@
 "cpd00205_c0":1,
 "cpd00205_e0":-1
 },
-"lower_bound":-1000,
+"lower_bound":-1000.0,
 "upper_bound":1000.0,
 "gene_reaction_rule":"WP_014975926.1 and WP_080752378.1 and WP_014948678.1 and WP_014978627.1",
 "annotation":{
@@ -67820,6 +67820,10 @@
 {
 "id":"WP_049587125.1",
 "name":"fbpA"
+},
+{
+"id":"WP_049587894.1",
+"name":""
 }
 ],
 "id":"iHS4156",

--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #239** (CUSTOM-CI)
+- **PR #240** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Changes the GPR of `rxn00006_c0` from `(WP_049588336.1 and WP_039225577.1 and WP_152910875.1 and WP_049586869.1) or WP_049586869.1 or (WP_049588336.1 and WP_152910875.1 and WP_039225577.1) or WP_014977393.1` to `WP_049588336.1 or WP_039225577.1 or WP_152910875.1 or WP_049586869.1 or WP_014977393.1`

and makes no other changes to the model.

All of the genes currently in the GPR of `rxn00006_c0` were annotated (by RefSeq and eggNOG) as katA, katB, katE, and/or katG, all of which can independently catalyze this reaction without requiring the expression of any other genes ([source](https://journals.asm.org/doi/full/10.1128/jb.00999-12)). katG does seem to only function as a homodimer ([source](https://doi.org/10.1016/S0022-2836(03)00122-0)), but that would still mean that it should be ORed with the other genes and not ANDed with anything.

As with https://github.com/C-CoMP-STC/GEM-mit1002/pull/236, https://github.com/C-CoMP-STC/GEM-mit1002/pull/238, and #239 , the reason I looked into the GPR of `rxn00006_c0` in the first place is that I'm looking for all reactions with suspiciously many "and"s in their GPRs in an effort to improve the accuracy of the model’s gene essentiality predictions.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists