### PR TITLE
Fix: GPRs involving ccoG paralogs

### DIFF
--- a/model.json
+++ b/model.json
@@ -52699,7 +52699,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"WP_014949591.1 and WP_049588214.1 and WP_014979357.1 and WP_014949594.1 and WP_049587321.1 and WP_039220102.1 and WP_049588217.1 and WP_049587017.1",
+"gene_reaction_rule":"WP_014949591.1 and WP_049588214.1 and WP_014979357.1 and WP_014949594.1 and WP_039220102.1 and WP_049588217.1 and (WP_049587017.1 or WP_049587321.1)",
 "annotation":{
 "metanetx.reaction":"MNXR137932",
 "sbo":"SBO:0000655",
@@ -52952,7 +52952,7 @@
 },
 "lower_bound":0.0,
 "upper_bound":1000.0,
-"gene_reaction_rule":"WP_014949591.1 and WP_049588214.1 and WP_014979357.1 and WP_014949594.1 and WP_049587321.1 and WP_039220102.1 and WP_049588217.1 and WP_049587017.1",
+"gene_reaction_rule":"WP_014949591.1 and WP_049588214.1 and WP_014979357.1 and WP_014949594.1 and WP_039220102.1 and WP_049588217.1 and (WP_049587017.1 or WP_049587321.1)",
 "annotation":{
 "metanetx.reaction":"MNXR137931",
 "sbo":"SBO:0000185",
@@ -60175,7 +60175,7 @@
 "cpd00205_c0":1,
 "cpd00205_e0":-1
 },
-"lower_bound":-1000,
+"lower_bound":-1000.0,
 "upper_bound":1000.0,
 "gene_reaction_rule":"WP_014975926.1 and WP_080752378.1 and WP_014948678.1 and WP_014978627.1",
 "annotation":{
@@ -67820,6 +67820,10 @@
 {
 "id":"WP_049587125.1",
 "name":"fbpA"
+},
+{
+"id":"WP_049587894.1",
+"name":""
 }
 ],
 "id":"iHS4156",

--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #239** (CUSTOM-CI)
+- **PR #241** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request changes the GPRs of `rxn14425_c0` and `rxn14426_c0` from
`WP_014949591.1 and WP_049588214.1 and WP_014979357.1 and WP_014949594.1 and WP_049587321.1 and WP_039220102.1 and WP_049588217.1 and WP_049587017.1`
to
`WP_014949591.1 and WP_049588214.1 and WP_014979357.1 and WP_014949594.1 and WP_039220102.1 and WP_049588217.1 and (WP_049587017.1 or WP_049587321.1)`
and makes no other changes to the model.

These reactions represent the activity of the cbb3-type cytochrome c oxidase:

`rxn14425_c0`: Ubiquinol-8 + Cytochrome-cbb-ox --> 2.0 H+ [e0] + Ubiquinone-8 + Cytochrome-cbb-red
`rxn14426_c0`: 0.5 O2 + 4.0 H+ + Cytochrome-cbb-red --> H2O + 2.0 H+ [e0] + Cytochrome-cbb-ox

All of the genes that currently appear in these GPRs are annotated as genes known to be essential for proper functioning of the cbb3-type cytochrome c oxidase (sources: [1](https://doi.org/10.1016/j.jmb.2005.11.039), [2](https://www.pnas.org/doi/epdf/10.1073/pnas.1913803116), [3](https://doi.org/10.3389/fmicb.2021.683260)):

- `WP_049587321.1` is ccoG
- `WP_049587017.1` is ccoG (see below)
- `WP_049588217.1` is ccoI
- `WP_049588214.1` is ccoN
- `WP_014979357.1` is ccoO
- `WP_039220102.1` is ccoP
- `WP_014949591.1` is ccoQ
- `WP_014949594.1` is ccoS

Apparently, many bacteria are known to have two ccoG-like genes, and in the few species where people have generated knockout strains, deleting only one only partially reduces the enzymatic activity of the whole complex ([source](https://doi.org/10.3389/fmicb.2021.683260)). Knockouts of any of the other genes (or both ccoGs) eliminate enzymatic activity altogether, so the only change I’m making to these GPRs is to OR the two ccoGs together but leave the two of them collectively ANDed to everything else. Just to be clear, all of what I just said was only shown in a handful of other bacteria, none of which are particularly close relatives of _Alteromonas macleodii_, but there’s also no evidence I can find to suggest that these genes have wildly different relationships in different organisms.

As with #236, #238, #239, and #240, this is part of my ongoing project to make sure that all GPRs with several genes ANDed together accurately reflect the relationships between those genes in an effort to improve the accuracy of gene essentiality predictions made with the model.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists