### PR TITLE
Fix: GPRs of lactate dehydrogenase/oxidase reactions

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #243** (CUSTOM-CI)
+- **PR #245** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Changes the GPR of `rxn00145_c0` from `WP_039227034.1 and WP_015068029.1 and WP_049588512.1` to `WP_015068029.1 or WP_049588512.1`
- Changes the GPRs of `rxn08792_c0` and `rxn08793_c0` from `(WP_039227034.1 and WP_015068029.1 and WP_049588512.1) or (WP_039227034.1 and WP_015068029.1 and WP_049588512.1)` to `WP_039227034.1`
- Removes `rxn00499_c0` from the model

All four reactions are redox reactions between lactate and pyruvate using different cofactors: `rxn00145_c0` uses cytochrome c, `rxn00499_c0` uses NAD(H), `rxn08792_c0` uses uniquinone/ol, and `rxn08793_c0` uses menaquinone/ol. They also have effectively the same GPRs, involving these genes:

- `WP_039227034.1` was annotated as K10530, lctO (lactate oxidase), which [was shown](http://doi.org/10.1111/febs.13162) to catalyze redox between lactate/pyruvate and some benzoquinones (not specifically ubiquinone or menaquinone, but very similar compounds)
- `WP_015068029.1` and `WP_049588512.1` were both annotated as lldD, which [KEGG](https://www.genome.jp/dbget-bin/www_bget?ko:K00101) describes as catalyzing `rxn00145_c0` (but not the other reactions)

Both lactate oxidase and lldD are consistently referred to as NAD-independent lactate dehydrogenases (sources: [1](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0036519), [2](https://journals.asm.org/doi/full/10.1128/mbio.00852-24)), so none of these genes seem appropriate to associate with `rxn00499_c0`. I can’t find any trace of genes annotated as NAD-dependent lactate dehydrogenases, so I’m not finding any evidence that `rxn00499_c0` actually occurs in this strain, and removing it shouldn’t impact the model’s ability to grow or anything, since the other reactions are only minor variations on `rxn00499_c0`.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists