### PR TITLE
Fix: GPR of rxn00192_c0

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #244** (CUSTOM-CI)
+- **PR #246** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Changes the GPR of `rxn00192_c0` from `WP_049588331.1 or (WP_044556927.1 and WP_049587731.1 and WP_049587772.1 and WP_049588110.1 and WP_049588449.1 and WP_014948922.1)` to `WP_049588331.1 or WP_014948049.1`
- Removes `WP_044556927.1`, `WP_049587731.1`, `WP_049587772.1`, `WP_049588110.1`, `WP_049588449.1`, and `WP_014948922.1` from the model

These are the RefSeq and eggNOG annotations for all of the genes currently in the GPR of `rxn00192_c0`:

- `WP_049588331.1`: argA “N-acetylglutamate synthase”, [K14682](https://www.genome.jp/dbget-bin/www_bget?ko:K14682) (this reaction)
- `WP_044556927.1`: HPA2 “histone acetyltransferase” or yhbS “predicted N-acetyltransferase”
- `WP_049587731.1`: rimL or rimJ, [2.3.1.267](https://www.genome.jp/entry/2.3.1.267) (not this reaction)
- `WP_049587772.1`: yhbS “predicted N-acetyltransferase”
- `WP_049588110.1`: GNAT family N-acetyltransferase
- `WP_049588449.1`: yhbS or rimI (acetylates residues of ribosomal protein S18)
- `WP_014948922.1`: GNAT family N-acetyltransferase

For reference, `rxn00192_c0` is L-Glutamate + Acetyl-CoA -> N-Acetyl-L-glutamate + CoA + H<sup>+</sup>

The GNAT family of N-acetyltransferases is [enormous](https://doi.org/10.3390/ijms17071018), and the different enzymes within it have all sorts of different substrate preferences, so just knowing that a gene encodes a member of this family with no further details tells us basically nothing about which reactions it should be associated with. [The only paper I can find about yhbS](https://www.pnas.org/doi/epub/10.1073/pnas.2106964118) characterizes its role in an entirely non-metabolic signalling pathway. The rim proteins [seem to](https://onlinelibrary.wiley.com/doi/full/10.1110/ps.035899.108) bind to several side chains around the particular residue that they acetylate in their target proteins, and while I can’t find anything that directly shows whether or not they can acetylate individual amino acids that aren’t part of larger proteins, I find it somewhat unlikely. I happened to notice that `WP_014948049.1` was annotated as argA/argH, capable of catalyzing both 2.3.1.1 (`rxn00192_c0`) and 4.3.2.1 (`rxn00802_c0`), and `WP_014948049.1` is currently only in the GPR of `rxn00802_c0`, so I’m also adding it to the GPR of `rxn00192_c0`.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
