### PR TITLE
Fix: glutamate synthase/dehydrogenase GPRs

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #244** (CUSTOM-CI)
+- **PR #248** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Changes the GPR of `rxn00085_c0` from `WP_012519580.1 and WP_049586503.1 and WP_014950543.1 and WP_014975770.1` to `WP_012519580.1 and WP_014950543.1`
- Changes the GPR of `rxn00184_c0` from `(WP_049587790.1 and WP_049588184.1 and WP_012516877.1) or WP_012519580.1 or (WP_014975770.1 and WP_014950543.1 and WP_049586503.1)` to `WP_049587790.1 or WP_049588184.1 or WP_012516877.1 or (WP_012519580.1 and WP_014950543.1)`
- Changes the GPR of `rxn00189_c0` from `(WP_049586789.1 and WP_014948979.1) or WP_049588023.1 or WP_049585995.1` to `(WP_049586789.1 and WP_014948979.1) or WP_049588023.1 or (WP_012519580.1 and WP_014950543.1)`
- Removes `WP_014975770.1` and `WP_049586503.1` from the model

For reference:

`rxn00085_c0`: NADP<sup>+</sup> + 2 L-Glutamate <=> NADPH + 2-Oxoglutarate + L-Glutamine + H<sup>+</sup>
`rxn00184_c0`: L-Glutamate + NADP<sup>+</sup> + H<sub>2</sub>O <=> 2-Oxoglutarate + NADPH + NH<sub>3</sub> + H<sup>+</sup>
`rxn00189_c0`:  L-Glutamine + H<sub>2</sub>O -> L-Glutamate + NH<sub>3</sub>

and here are the RefSeq and/or eggNOG annotations for all of the genes currently associated with those reactions:

- `WP_049587790.1`: gdhA, 1.4.1.4 (only `rxn00184_c0`)
- `WP_049588184.1`: gdhA, 1.4.1.4 (only `rxn00184_c0`)
- `WP_012516877.1`: gdhA, 1.4.1.4 (only `rxn00184_c0`)
- `WP_012519580.1`: gltD, 1.4.1.13 (`rxn00085_c0` and `rxn00189_c0`; forms a complex with gltB)
- `WP_014975770.1`: thioredoxin family protein (not relevant to any of these reactions)
- `WP_014950543.1`: gltB (`rxn00085_c0` and `rxn00189_c0`; forms a complex with gltD)
- `WP_049586503.1`: glycosyl transferase family 1 (not relevant to any of these reactions)
- `WP_049586789.1`: carB, [6.3.5.5](https://www.genome.jp/entry/6.3.5.5), K01955 (only `rxn00189_c0`; forms a complex with carA)
- `WP_014948979.1`: carA, [6.3.5.5](https://www.genome.jp/entry/6.3.5.5), K01955 (only `rxn00189_c0`; forms a complex with carB)
- `WP_049588023.1`: glsA,[3.5.1.2](https://www.genome.jp/entry/3.5.1.2), K01425 (only `rxn00189_c0`)
- `WP_049585995.1`: purL, [6.3.5.3](https://www.genome.jp/entry/6.3.5.3), K01952 (only `rxn03084_c0`, which it is already associated with)

I see no reason to believe that the first three genes aren’t independently functional isozymes of each other, and [KEGG](https://www.genome.jp/entry/1.4.1.13) clearly states that gltD and gltB form a complex. The annotations for `WP_014975770.1` and `WP_049586503.1` are not specific enough to determine which other reactions they would be appropriate to associate with, so I’m just removing them from the model.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists