### PR TITLE
Fix: alkaline phosphatase GPRs

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #245** (CUSTOM-CI)
+- **PR #249** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Changes the GPRs of `rxn00743_c0` and `rxn02166_c0` from `WP_049586043.1 and WP_014949867.1 and WP_049585855.1` to `WP_049587995.1 or WP_049586043.1 or WP_014949867.1 or WP_049586739.1`
- Changes the GPR of `rxn03167_c0` from `(WP_049587995.1 and WP_049588550.1 and WP_049586043.1 and WP_014949867.1 and WP_049585855.1) or WP_049586739.1` to `WP_049587995.1 or WP_049586043.1 or WP_014949867.1 or WP_049586739.1`
- Removes `WP_049588550.1` and `WP_049585855.1` from the model

Only some of the genes that are currently in the GPRs of these reactions are annotated with relevant functions by RefSeq and/or eggNOG:

- `WP_049587995.1`: phoA, 3.1.3.1
- `WP_049588550.1`: “esterase-like activity of phytase”
- `WP_049586043.1`: “alkaline phosphatase” (no further details or specific gene/protein names)
- `WP_014949867.1`: phoX, 3.1.3.1
- `WP_049585855.1`: [yncE](https://link.springer.com/article/10.1007/s00284-015-0967-7) or “amine dehydrogenase activity” (neither are relevant)
- `WP_049586739.1`: phoD, 3.1.3.1

For reference:

`rxn00743_c0`: Glycerone-phosphate + H<sub>2</sub>O --> Glycerone + Phosphate
`rxn02166_c0`: 4-Nitrophenyl phosphate + H<sub>2</sub>O --> PNP + Phosphate
`rxn03167_c0`: 7,8-Dihydroneopterin 3'-triphosphate + 3 H<sub>2</sub>O => Dihydroneopterin + 3 Phosphate + 2 H<sup>+</sup>

Also, all of those alkaline phosphatases appear to be independently functional isozymes and not subunits of a complex, so I’m replacing the “and”s in the original GPR with “or”s. The annotations for `WP_049588550.1` and `WP_049585855.1` don’t seem specific/metabolic enough to justify associating them with any reactions in the model, so I’m removing them.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists