### PR TITLE
Fix: GPRs of alcohol dehydrogenase reactions

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #245** (CUSTOM-CI)
+- **PR #250** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request changes the GPRs of the following reactions:

ID | reaction | current GPR | new GPR
---|---|---|---
`rxn00171_c0` | NAD<sup>+</sup> + CoA + Acetaldehyde <=> NADH + Acetyl-CoA + H<sup>+</sup> | `WP_049588588.1 or (WP_049587342.1 and WP_014977336.1 and WP_049588907.1 and WP_049586860.1 and WP_049588854.1)` | `WP_049588588.1`
`rxn00543_c0` |  NAD<sup>+</sup> + Ethanol <=> NADH + H<sup>+</sup> + Acetaldehyde | `WP_049587342.1 or WP_014977336.1 or WP_049588907.1 or WP_049586860.1 or WP_049588854.1` | `WP_049587342.1 or WP_049588907.1 or WP_049586860.1`
`rxn00762_c0` | NAD<sup>+</sup> + Glycerol <=> NADH + H<sup>+</sup> + Glycerone | `WP_049587342.1 and WP_014977336.1 and WP_049588907.1 and WP_049586860.1 and WP_049588854.1` | `WP_049587342.1 or WP_049588907.1 or WP_049586860.1`
`rxn00763_c0` | NAD<sup>+</sup> + Glycerol <=> NADH + H<sup>+</sup> + D-Glyceraldehyde | `WP_049587342.1 and WP_014977336.1 and WP_049588907.1 and WP_049586860.1 and WP_049588854.1` | `WP_049587342.1 or WP_049588907.1 or WP_049586860.1`
`rxn01079_c0` | NADP<sup>+</sup> + Gulonate <=> NADPH + H<sup>+</sup> + Glucuronate | `WP_080986362.1` | `WP_080986362.1 or WP_049588854.1`
`rxn01201_c0` | NAD<sup>+</sup> + 4-Hydroxybutanoate <=> NADH + H<sup>+</sup> + 4-Oxobutanoate | `WP_049588907.1 or WP_085929484.1` | `WP_049587342.1 or WP_049588907.1 or WP_049586860.1`
`rxn01480_c0` | NAD<sup>+</sup> + 3-Hydroxyisobutyrate <=> NADH + H+ + 3-Oxo-2-methylpropanoate | `WP_085929484.1 or WP_049588754.1` | `WP_049587342.1 or WP_049588907.1 or WP_049586860.1`
`rxn01710_c0` | NADH + H<sup>+</sup> + Propanal <=> NAD<sup>+</sup> + Propanol | `WP_049587342.1 and WP_014977336.1 and WP_049588907.1 and WP_049586860.1 and WP_049588854.1` | `WP_049587342.1 or WP_049588907.1 or WP_049586860.1`
`rxn10770_c0` | NAD<sup>+</sup> + Choline <=> NADH + H<sup>+</sup> + Betaine aldehyde | `(WP_049587147.1 and WP_049587746.1) or (WP_049587342.1 and WP_014977336.1 and WP_049588907.1 and WP_049586860.1 and WP_049588854.1)` | `WP_049587147.1 or WP_049587746.1 or WP_049587342.1 or WP_049588907.1 or WP_049586860.1`

and removes `WP_014977336.1` and `WP_085929484.1` from the model.

All of the above reactions represent redox of alcohols or similar compounds have largely overlapping sets of genes in their GPRs, but there are several problems with the current mapping between these genes and these reactions:

- `WP_049588588.1`: mhpF, [1.2.1.10](https://www.genome.jp/entry/1.2.1.10) (`rxn00171_c0`)
- `WP_049587342.1`: alcohol dehydrogenase [1.1.1.1](https://www.genome.jp/entry/1.1.1.1) (`rxn00543_c0`, `rxn00763_c0`, `rxn01201_c0`, `rxn01480_c0`, `rxn01710_c0`, and `rxn10770_c0`)
- `WP_014977336.1`: COG0604: NADPH quinone reductase and related Zn-dependent oxidoreductases (too vague to tell which reaction(s) would be appropriate)
- `WP_049588907.1`: eutG, [1.1.1.1](https://www.genome.jp/entry/1.1.1.1) (`rxn00543_c0`, `rxn00763_c0`, `rxn01480_c0`, `rxn01710_c0`, and `rxn10770_c0`)
- `WP_049586860.1`: alcohol dehydrogenase (`rxn00543_c0`, `rxn00763_c0`, `rxn01480_c0`, `rxn01710_c0`, and `rxn10770_c0`)
- `WP_049588854.1`: yjgB, [1.1.1.2](https://www.genome.jp/entry/1.1.1.2) and [1.1.1.183](https://www.genome.jp/entry/1.1.1.183) (`rxn01079_c0`)
- `WP_049587147.1`: betA, [1.1.99.1](https://www.genome.jp/entry/1.1.99.1) (`rxn10770_c0`)
- `WP_049587746.1`: betA, [1.1.99.1](https://www.genome.jp/entry/1.1.99.1) (`rxn10770_c0`)
- `WP_080986362.1`: ytbE, [1.1.1.2](https://www.genome.jp/entry/1.1.1.2) and [1.1.1.307](https://www.genome.jp/entry/1.1.1.307) (`rxn01079_c0` and `rxn01392_c0`)
- `WP_085929484.1`: invalid RefSeq ID (also not annotated by eggNOG)
- `WP_049588754.1`: fadN, [1.1.1.35](https://www.genome.jp/entry/1.1.1.35) (none of these, but already associated with appropriate reactions like `rxn03244_c0`)

None of these seem to form complexes with the products of any other genes, which is why all of my new GPRs only contain “or”s and no “and”s.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists