### PR TITLE
Fix: GPR of rxn01913_c0

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #245** (CUSTOM-CI)
+- **PR #251** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Changes the GPR of `rxn01913_c0` from `WP_049588754.1` to `` (empty string; see below)

and makes no other changes to the model.

`WP_049588754.1` was annotated as fadN, [1.1.1.35](https://www.genome.jp/entry/1.1.1.35), which only acts on 3-hydroxyacyl-CoAs, and `rxn01913_c0` does not involve an acyl-CoA. The E.C. number for `rxn01913_c0` is 1.1.1.45, but neither RefSeq nor eggNOG annotated any genes with this E.C. number. It seems plausible that some of the genes mentioned in #250 might encode enzymes capable of catalyzing this reaction (consider what [this paper](https://onlinelibrary.wiley.com/doi/full/10.1111/mmi.14259) found, for instance), but it’s not clear to me exactly which genes would be appropriate to associate with this reaction. So for now, I’m just leaving it in the model with an empty GPR, since there’s some reason to believe that MIT1002 can catalyze this reaction, but it’s not clear exactly which gene(s) it needs to do so (but it is clear that `WP_049588754.1` is not that gene). For the record, `WP_049588754.1` is already associated with plenty of reactions that it should be associated with, like `rxn03244_c0`.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists