### PR TITLE
Fix: add more isozymes to fatty acid oxidation GPRs

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #245** (CUSTOM-CI)
+- **PR #252** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Changes the GPRs of `rxn02167_c0`, `rxn03250_c0`, `rxn03247_c0`, `rxn03245_c0`, `rxn02911_c0`, `rxn03241_c0`, `rxn03240_c0`, `rxn02949_c0`, and `rxn02934_c0` to `(WP_049588521.1 and WP_024015658.1) or (WP_049585918.1 and WP_049585851.1) or WP_014976911.1 or WP_014948837.1 or WP_049588954.1 or WP_049586519.1 or WP_049586236.1 or WP_049587152.1`
- Changes the GPRs of `rxn00874_c0`, `rxn03248_c0`, `rxn02680_c0`, `rxn03243_c0`, `rxn06510_c0`, and `rxn02804_c0` to `(WP_049588521.1 and WP_024015658.1) or (WP_049585918.1 and WP_049585851.1) or WP_049588755.1 or WP_049586525.1 or WP_014977341.1`

While working on copying the changes made in #236 to the [HOT1A3](https://github.com/segrelab/GEM-hot1a3/pull/9) and [ATCC27126](https://github.com/segrelab/GEM-atcc27126/pull/12) models, I came across a few more enoyl-CoA hydratases and thiolases in the MIT1002 genome that I didn’t notice when I was working on #236. See #236 for more details about these reactions.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists