### PR TITLE
Fix: remove dipeptide exchange and transport reactions

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #261** (CUSTOM-CI)
+- **PR #262** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Removes reactions `EX_cpd01017_e0`, `rxn05539_c0`, `EX_cpd00731_e0`, and `rxn08098_c0` from the model
- Removes metabolites `cpd01017_e0` (cysteinylglycine) and `cpd00731_e0` (alanylalanine) from the model
- Removes gene `WP_049587892.1` from the model

`rxn05539_c0` and `rxn08098_c0` represent ATP-dependent import of cysteinylglycine or alanylalanine into the cell. `WP_049587892.1` was only annotated as a member of [the “Peptide/Opine/Nickel Uptake Transporter” family of ABC transporters](https://www.tcdb.org/search/result.php?tc=3.A.1.5#3.A.1.5), and not any specific member of that family. While some members of that family are dipeptide transporters, many are not, so just knowing that this gene is a member of that family is not evidence that it transports cysteinylglycine or alanylalanine. `rxn05539_c0` and `rxn08098_c0` were the only two reactions that `WP_049587892.1` was associated with. I am removing the extracellular dipeptide metabolites but leaving their cytosolic equivalents for the moment — I may also wind up removing them in a future PR, but need to investigate the other (non-transport) reactions that they participate in first.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists