### PR TITLE
Feat: add GPRs for rxn01637_c0 and rxn03087_c0

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #261** (CUSTOM-CI)
+- **PR #263** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Adds new gene `WP_049588781.1` (argD) to the model
- Sets the currently empty GPR of `rxn01637_c0` to `WP_049588781.1`
- Sets the currently empty GPR of `rxn03087_c0` to `WP_049588781.1`

I added both of these reactions without GPRs in #141 and #143 because I couldn’t find any genes annotated as argD (the enzyme responsible for both reactions), but that was because I only looked at the GFF file and not the eggNOG annotations, which clearly annotate `WP_049588781.1` as argD.

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists