### PR TITLE
Fix: revert some changes made in #227

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #261** (CUSTOM-CI)
+- **PR #264** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Changes the GPR of `rxn01664_c0` from `WP_049585722.1` to an empty string
- Changes the GPR of `rxn45861_c0` from `WP_049586037.1 or WP_049588112.1` to `WP_049586037.1`

`rxn01664_c0` is a spontaneous reaction, which is why I intentionally gave it no GPR back in #216. I apparently forgot about that when working on #227. `WP_049588112.1` was annotated as being capable of catalyzing `rxn45861_c0` by the pangenome analysis, but the pangenome analysis annotated it as K26065, which is associated with an unbalanced version of this reaction (R08414) that lacks an electron donor/acceptor. KEGG has a different version (R02206) that includes a generic “acceptor” metabolite, so if the situation is that K26065 is known to catalyze this reaction but the identity of the electron donor/acceptor is unknown, it should’ve been associated with R02206 and not R08414. Furthermore, neither of the two papers KEGG includes as references on the page for K26065 actually mention this reaction, so I’m not convinced that K26065 can actually catalyze redox of pipecolate. `WP_049586037.1` is clearly annotated as an enzyme that can catalyze this reaction (see #216).

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists