### PR TITLE
Fix: unnecessary rhamnose anomers

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #267** (CUSTOM-CI)
+- **PR #268** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Removes `rxn15337_c0`: beta-L-Rhamnose <=> L-Rhamnulose
- Removes `rxn15338_c0`: alpha-L-Rhamnose <=> L-Rhamnulose
- Removes `rxn26307_c0`: alpha-L-Rhamnose <=> beta-L-Rhamnose
- Removes alpha-L-Rhamnose (`cpd01627_c0`) from the model
- Removes beta-L-Rhamnose (`cpd01562_c0`) from the model
- Removes `WP_080986447.1` from the model

This solves basically the same problem as #211, but with rhamnose instead of glucose (also see [these](https://journals.asm.org/doi/full/10.1128/jb.01120-07) [papers](https://doi.org/10.1016/j.bbrc.2020.05.094) for evidence that the differences between glucose anomers are comparable to the differences between rhamnose anomers). The non-anomer-specific version of L-rhamnose is already in the model as `cpd00642_c0`. `rxn26307_c0` is the only reaction that `WP_080986447.1` is associated with, and it doesn’t seem to be capable of catalyzing any other reactions.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists