### PR TITLE
feat: add rxn00932_c0, cpd00851_c0, and WP_049587685.1

### DIFF
--- a/test/test_files/test_results/README.md
+++ b/test/test_files/test_results/README.md
@@ -2,6 +2,6 @@
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #267** (CUSTOM-CI)
+- **PR #270** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Adds new gene `WP_049587685.1`: proline 4-hydroxylase
- Adds new metabolite `cpd00851_c0`: trans-4-hydroxy-L-proline
- Adds new reaction `rxn00932_c0`: O2 [c0] + 2-Oxoglutarate [c0] + L-Proline [c0] --> CO2 [c0] + Succinate [c0] + trans-4-Hydroxy-L-proline [c0], GPR: `WP_049587685.1`

I came across this while looking for reactions that are in some but not all of the MIT1002, ATCC 27126, and HOT1A3 models, and noticed that `rxn00932_c0` only appeared in the ATCC 27126 model, but eggNOG also annotated `WP_049587685.1` in the MIT1002 genome with the E.C. number for `rxn00932_c0`.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists