### PR TITLE
Fix: Remove rxn00656_c0, rxn24212_c0, and WP_197047972.1

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #290** (CUSTOM-CI)
+- **PR #291** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Removes `rxn00656_c0` from the model for effectively being a duplicate of `rxn00657_c0`
- Removes `rxn24212_c0` from the model for effectively being a duplicate of `rxn01204_c0`
- Removes gene `WP_197047972.1` from the model

`rxn00656_c0`: L-Alanine + 3-Oxopropanoate <=> Pyruvate + β-Alanine
`rxn24212_c0`: Pyruvate + GABA <=> L-Alanine + 4-Oxobutanoate

As mentioned in #283, `WP_197047972.1` isn’t actually in the MIT1002 genome, and was only “inferred to be present” by the pangenome analysis because it could catalyze steps of one or more pathways for which the genes responsible for catalyzing most of the other steps were actually in the genome. In #283, I failed to notice that `WP_197047972.1` was not just in the GPR of `rxn00317_c0`, but also `rxn00656_c0` and `rxn24212_c0`, so I accidentally made the SBML file invalid when I tried removing `WP_197047972.1` without also removing those reactions or editing their GPRs.

It turns out that `rxn00656_c0` and `rxn24212_c0` have the same problem as `rxn00317_c0`: the model already has functionally equivalent reactions associated with a gene that is actually in the MIT1002 genome and annotated with the relevant enzymatic activity. In this case, the functionally equivalent reactions are `rxn00657_c0` and `rxn01204`_c0, which use glutamate and 2-oxoglutarate instead of alanine and pyruvate but are otherwise the same as `rxn00656_c0` and `rxn24212_c0`, respectively, and the gene associated with both reaction is ‘WP_049588781.1`, which was annotated with appropriate E.C. numbers and actually appears in the MIT1002 genome.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [ ] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
