### PR TITLE
Fix: remove rxn00227_c0, rxn01103_c0, and WP_015066019.1

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #290** (CUSTOM-CI)
+- **PR #292** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Removes `rxn00227_c0`: H2O + Acetylphosphate => Phosphate + Acetate + H+
- Removes `rxn01103_c0`: H2O + 1,3-Bisphospho-D-glycerate => Phosphate + H+ + 3-Phosphoglycerate
- Removes gene `WP_015066019.1` from the model

While looking into reactions that are currently in the MIT1002 model but not the ATCC27126 and/or HOT1A3 models to make sure they represent actual differences between the strains and not curation errors, I noticed that `rxn00227_c0` and `rxn01103_c0` are both only in the MIT1002 model and both only associated with `WP_015066019.1`, which was only annotated with [a KEGG ortholog ID for a protein with no known catalytic activity](https://www.genome.jp/entry/K04656). Neither eggNOG nor the pangenome analysis annotated any genes in the MIT1002 genome with the E.C. number for `rxn00227_c0` and `rxn01103_c0` (3.6.1.7), and removing those reactions doesn’t seem to impact the model’s ability to grow on the few media combinations I tested, so I’m removing them along with `WP_015066019.1`.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [X] Tested my code on my own computer for running the model
- [X] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists