### PR TITLE
Fix: remove dead-end metabolites indole-3-acetamide & indole-3-acetate

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #290** (CUSTOM-CI)
+- **PR #293** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Removes `rxn02222_c0`: H2O + Indole-3-acetamide => NH3 + Indoleacetate, GPR: `WP_039229281.1`
- Removes dead-end metabolite indole-3-acetamide (`cpd01747_c0`) from the model
- Removes dead-end metabolite indoleacetate (`cpd00703_c0`) from the model

`WP_039229281.1` was only annotated with the E.C. number for `rxn00654_c0` (3.5.1.6), and it is already in the GPR of `rxn00654_c0`. While `WP_049588844.1` was annotated as broad-specificity amidase that could theoretically catalyze `rxn02222_c0`, no other reactions in the model consume or produce indole-3-acetamide or indoleacetate, so I don’t think that the presence of `WP_049588844.1` alone is particularly compelling evidence that `rxn02222_c0` actually occurs in MIT1002. I came across this reaction while working on #288.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists