### PR TITLE
Fix: restore growth on acetate by fixing nitrate/nitrite redox reactions

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #293** (CUSTOM-CI)
+- **PR #299** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Adds new reaction `rxn05894_c0`: Nitrate + Reduced ferredoxin + 2 H<sup>+</sup> --> Nitrite + Oxidized ferredoxin + H<sub>2</sub>O, GPR: `WP_039227383.1`
- Adds `rxn14427_c0`: Nitrate + 2 Cytochrome c<sup>2+</sup> + 2 H<sup>+</sup> [e0] <=> Nitrite + 2 Cytochrome c<sup>3+</sup> + H<sub>2</sub>O, GPR: `WP_049586998.1`
- Removes `rxn00569_c0`: Nitrite + 3 NADPH + 4 H+ <=> Ammonia + 3 NADP+ + 2 H2O
- Removes `rxn00571_c0`: Nitrate + NADH + 2 H+ --> Nitrite + NAD + H2O
- Removes `rxn00572_c0`: Nitrate + NADPH + 2 H+ --> Nitrite + NADP + H2O
- Removes `rxn09001_c0`: Nitrate + Ubiquinol-8 --> Nitrite + Ubiquinone-8 + H2O

Adding `rxn14427_c0` back to the model, but as a reversible and balanced reaction (it was irreversible and charge-imbalanced when I removed it in #275), restores the model’s ability to grow on acetate in L1 media, which it has been unable to do since #274. As far as I can tell, changing the coefficients of the cytochrome c metabolites in #274 left the model unable to reduce enough cytochrome c to use the electron transport chain to fuel biomass production, and allowing the model to reduce cytochrome c by oxidizing nitrite resolves that. [This paper](https://www.jbc.org/article/S0021-9258(20)52252-7/fulltext) mentions that one of the physiological functions of cytochrome c-dependent nitrate reductases is to “dispose of excess reducing equivalents”, so there’s some precedent for this idea. Also see [this paper](https://pubs.acs.org/doi/10.1021/jacs.4c17874) for evidence that nitrate reductases can be reversible.

I am also adding `rxn05984_c0` and removing several reactions, some of which I added in #275, because this time I took a closer look at the annotations of all of the nitrate/nitrite/ammonia oxidoreductases from the pangenome analysis (and not just the annotations from eggNOG):

- `WP_049586997.1` and `WP_014975661.1`: form a complex that catalyzes NAD-dependent redox between nitrite & ammonia (`rxn00568_c0`, which already has an appropriate GPR; I’m only mentioning these here because this is different from what I said they do in #275)
- `WP_049586998.1`: cytochrome c-dependent redox between nitrate and nitrite (`rxn14427_c0`)
- `WP_039227383.1`: ferredoxin-dependent redox between nitrite and ammonia (`rxn05894_c0`)

Note that, while napA (`WP_049586998.1`) forms a complex with napB in many organisms, and no genes in the MIT1002 genome were annotated as napB, [this paper](https://www.jbc.org/article/S0021-9258(20)52252-7/fulltext) mentions that several organisms have independently functional napAs, so the absence of napB is not necessarily a cause for concern. The model already contains several reactions that use different electron donors/acceptors than the ones listed above, and I am removing all of those, since I am now confident that I have found all of the genes annotated as nitrate/nitrite/ammonia (oxido)reductases and know which electron donors/acceptors they are known to use.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [X] Tested my code on my own computer for running the model
- [X] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists