### PR TITLE
Fix: copper and heavy metal transporters

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #302** (CUSTOM-CI)
+- **PR #303** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Adds new genes copC (`WP_012516837.1`) and copD (`WP_049587497.1`) to the model
- Adds new reaction `rxn05212_c0`: Cu<sup>2+</sup> [e0] --> Cu<sup>2+</sup> [c0], GPR: `WP_012516837.1 and WP_049587497.1`
- Adds new metabolite Cu<sup>+</sup> (`cpd30760_c0` & `cpd30760_e0`)
- Adds new reaction `EX_cpd30760_e0`: Cu<sup>+</sup> [e0] -->
- Replaces Cu<sup>2+</sup> (`cpd00058`) with Cu<sup>+</sup> (`cpd30760`) in `rxn08275_c0`
- Makes `rxn08275_c0` reversible
- Changes the GPR of `rxn08275_c0` from `WP_049586048.1 and WP_012516834.1 and WP_049587498.1 and WP_039227932.1 and WP_014996986.1 and WP_049586047.1` to `WP_049586048.1 and WP_012516834.1 and WP_049587498.1 and WP_049586047.1`
- Changes the ID of `rxn08275_c0` to `rxn29147_c0`
- Changes the GPR of `rxn05528_c0` from `WP_049587504.1 and WP_049588217.1 and WP_012516907.1` to `WP_049588217.1`
- Removes `rxn10481_c0`: H2O + ATP + Cu<sup>2+</sup> [e0] --> ADP + Phosphate + Cu<sup>2+</sup> [c0] + H<sup>+</sup>
- Removes `EX_cpd00531_e0`: Hg<sup>2+</sup> [e0] -->
- Removes `EX_cpd01012_e0`: Cd<sup>2+</sup> -->
- Removes `EX_cpd04097_e0`: Pb [e0] -->
- Removes `rxn02021_c0`: NADP<sup>+</sup> + Hg <=> NADPH + H+ + Hg<sup>2+</sup>
- Removes `rxn05315_c0`: H<sup>+</sup> [e0] + K<sup>+</sup> [e0] + Zn<sup>2+</sup> <=> H<sup>+</sup> + K<sup>+</sup> + Zn<sup>2+</sup> [e0]
- Removes `rxn05516_c0`: H2O + ATP + Cd<sup>2+</sup> --> ADP + Phosphate + H<sup>+</sup> + Cd<sup>2+</sup> [e0]
- Removes `rxn05517_c0`: H<sup>+</sup> [e0] + K<sup>+</sup> [e0] + Cd<sup>2+</sup> <=> H<sup>+</sup> + K<sup>+</sup> + Cd<sup>2+</sup> [e0]
- Removes `rxn08715_c0`: H2O + ATP + Hg<sup>2+</sup> --> ADP + Phosphate + H<sup>+</sup> + Hg<sup>2+</sup> [e0]
- Removes `rxn10344_c0`: H2O + ATP + Pb --> ADP + Phosphate + H<sup>+</sup> + Pb [e0]
- Removes Cd<sup>2+</sup> (`cpd01012_c0` & `cpd01012_e0`) from the model
- Removes Hg<sup>2+</sup> (`cpd00531_c0` & `cpd00531_e0`) from the model
- Removes Hg (`cpd00965_c0`) from the model
- Removes Pb (`cpd04097_c0` & `cpd04097_e0`) from the model
- Removes genes `WP_012801201.1`, `WP_012516887.1`, `WP_045980004.1`, `WP_039229202.1`, `WP_012516907.1`, `WP_049587504.1`, `WP_045980005.1`, `WP_039227932.1`, and `WP_014996986.1` from the model

Here’s a summary of the annotations of all of the genes that appear in the above reactions’ GPRs:

- `WP_012801201.1` was annotated with the E.C. number for `rxn02021_c0`
- `WP_049588217.1` was annotated with the E.C. number for `rxn05528_c0`
- `WP_049586048.1`, `WP_012516834.1`, `WP_049587498.1`, and `WP_049586047.1` were annotated with T.C. 2.A.6.1.4, which specifically transports Cu<sup>+</sup> (`cpd30760`) and not Cu<sup>2+</sup> (`cpd00058`; [source](https://doi.org/10.1007/s10534-013-9628-0)).
- `WP_012516887.1`, `WP_045980004.1`, and `WP_039229202.1` were all annotated with T.C. 2.A.4.1, which is a group of seven transporters, and while 6 are known to transport zinc, one has never been characterized and only some of them are known to transport metals other than zinc, so this isn’t really specific enough to know which reactions to associate these genes with.
- `WP_012516907.1` was annotated with T.C. 3.A.3.5, which is a larger group of transporters that are mostly but not exclusively capable of transporting copper, and some members are only known to transport other members, so that’s not specific enough to know which reactions it would be appropriate to associate `WP_012516907.1` with.
- `WP_045980005.1`, `WP_039227932.1`, and `WP_014996986.1` weren’t annotated with any specific functions.
- `WP_049587504.1` doesn’t actually seem to be in the MIT1002 genome at all.

The mechanisms of toxicity of heavy metals are [largely non-metabolic](https://doi.org/10.1080/1040841X.2021.1970512) (e.g. denaturing proteins, disrupting membrane integrity) or otherwise beyond the scope of stead-state models (inhibiting enzymes), so I’m removing all of these except the copper ones, since copper is in the biomass reaction. Most of the reactions that I’m removing are currently only in the MIT1002 model but not the HOT1A3 or ATCC27126 models, but it’s not clear that we have any genomic evidence that the three strains have different capacities to tolerate or detoxify heavy metals.

Cu<sup>+</sup> (`cpd30760`) is not currently in the model, and it’s not entirely clear to me what other reactions it might participate in, but since those genes are pretty clearly annotated as subunits of a monovalent copper transporter, I figured that the model should have that reaction, even if it’s a dead-end.

I couldn’t find any genes annotated as directly ATP-dependent divalent copper *importers* (`WP_049588217.1` was only annotated as an exporter), but I did find genes annotated as copC (`WP_012516837.1`) and copD (`WP_049587497.1`), which weren’t already in the model but are known to be copper transporters (sources: [1](https://doi.org/10.1007/978-94-007-5561-1_12),[2](https://doi.org/10.1021/ic070107o),[3](https://doi.org/10.1021/acs.biochem.6b00175)). So I’m replacing `rxn05528_c0` and `rxn10481_c0` with `rxn05212_c0` to ensure that the model accurately reflects the annotated functions of the genes it contains while also preserving its ability to import divalent copper, since it’s a reactant in the biomass reaction. I couldn’t really find any details about the mechanism by which copCD transport copper, except that copC binds periplasmic copper ions, then binds to copD, which is embedded in the plasma membrane.

Note that the model can still uptake zinc without `rxn05315_c0`, as it also has `rxn43657_c0`: Zn<sup>2+</sup> [e0] + H<sup>+</sup> [e0] --> Zn<sup>2+</sup> + H<sup>+</sup>, GPR: `WP_049588525.1`. `WP_049588525.1` was annotated with T.C. 2.A.5.5, which isn't a specific transporter, but every transporter in that group can transport zinc, so it seems appropriate to include in the GPR of `rxn43657_c0`. This matters because zinc is a reactant in the biomass reaction.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists