### PR TITLE
Fix: remove isolated genes and metabolites or add to appropriate reactions

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #302** (CUSTOM-CI)
+- **PR #304** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Changes the GPR of `rxn01201_c0` from `WP_049587342.1 or WP_049586860.1` to `WP_049587342.1 or WP_049586860.1 or WP_049588907.1` (should’ve happened in #285)
- Changes the GPR of `rxn08783_c0` from `WP_049586624.1` to `WP_049586624.1 or WP_049588824.1` (should’ve happened in #285)
- Adds gene `WP_039233285.1` to GPR of `rxn08762_c0` (should’ve happened in #239)
- Removes gene `WP_080986363.1` from the model (should’ve happened in #239)
- Removes genes `WP_014975770.1` and `WP_049586503.1` from the model (should’ve happened in #238)
- Removes genes `WP_049589095.1` and `WP_049587249.1` from the model (should’ve happened in #278 and/or #301)
- Removes gene `WP_049588465.1` from the model (should’ve happened in #280)
- Removes metabolite `cpd15793_c0` from the model (should’ve happened in #154)
- Removes metabolites `cpd26672_c0` and `cpd27484_c0` from the model (should’ve happened in #278 and/or #301)

I decided to check the model for isolated genes and reactions, just to see if I made any mistakes while removing reactions or editing GPRs, and I sure did.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [X] Tested my code on my own computer for running the model
- [X] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists