### PR TITLE
Fix: remove dead-end duplicate phenol catabolism pathway

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #302** (CUSTOM-CI)
+- **PR #305** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Removes `rxn01285_c0`: Tartrate + H+ --> Glycerate + CO2, GPR: `WP_049588587.1`
- Removes `rxn02788_c0`: 2-Hydroxymuconate --> 4-Oxalocrotonate, GPR: `WP_049588586.1`
- Removes `rxn01894_c0`: 4-Oxalocrotonate + H+ --> 2-Hydroxy-2,4-pentadienoate + CO2, GPR: `WP_049588587.1`
- Removes Tartrate (`cpd00666_c0`) from the model
- Removes 2-Hydroxymuconate (`cpd01644_c0`) from the model
- Removes 4-Oxalocrotonate (`cpd02183_c0`) from the model
- Removes genes `WP_049588586.1` and `WP_049588587.1` from the model

`WP_049588586.1` was just annotated as a “tautomerase enzyme”, with no further details. No genes were annotated with the E.C.s for `rxn01285_c0` (4.1.1.73) or `rxn02788_c0` (5.3.2.6). Tartrate (`cpd00666_c0`) and 2-Hydroxymuconate (`cpd01644_c0`) don’t participate in any reactions other than `rxn01285_c0` or `rxn02788_c0`, respectively, so I’m not seeing much evidence that they actually occur in this strain. `WP_049588587.1` was annotated with E.C. 4.1.1.77, which should be (3E)-2-oxohexenedioate -> 2-oxopent-3-enoate + CO2 (i.e. neither `rxn01285_c0` or `rxn01894_c0`), which doesn’t seem to be on ModelSEED. 2-oxopent-3-enoate is on ModelSEED as `cpd34681`, but the only reaction ModelSEED has with that metabolite is another isomerization reaction that would be catalyzed by 5.3.2.6, which no MIT1002 genes were annotated with. Aside from `rxn01285_c0`, all of these reactions and metabolites seem to be parts of a phenol catabolism pathway, but the model already has an intact phenol catabolism pathway with GPRs for each step that are supported by the annotations we have for those genes:

`rxn39979_c0`: NADH + O2 + H+ + Phenol --> H2O + NAD + Catechol
`rxn00587_c0`: O2 + Catechol --> H+ + 2-Hydroxymuconic semialdehyde
`rxn01896_c0`: 2-Hydroxymuconic semialdehyde + H2O <=> 2-Hydroxy-2,4-pentadienoate + Formate + H+
`rxn01893_c0`: 2-Hydroxy-2,4-pentadienoate + H2O --> 4-Hydroxy-2-oxovalerate
`rxn00540_c0`: 4-Hydroxy-2-oxovalerate <=> Pyruvate + Acetaldehyde (can be converted to acetate, ethanol, acetyl-CoA, or exported)

Since I can’t find any trace of the enzymes that would produce or consume the substrates of the reaction that `WP_049588587.1` is supposed to be capable of catalyzing, and the model already has a complete version of the pathway that it supposedly participates in, I’m just removing `WP_049588587.1` from the model.

All three reactions that this PR removes weren't in the HOT1A3 or ATCC27126 models, which is why I looked into them.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists