### PR TITLE
Fix: Replace NADP with NAD in enoyl-ACP-methyl-ester reduction reactions

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #302** (CUSTOM-CI)
+- **PR #306** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Replaces NADP<sup>+</sup> (`cpd00006_c0`) and NADPH (`cpd00005_c0`) with NAD<sup>+</sup> (`cpd00003_c0`) and NADH (`cpd00004_c0`) in `rxn21859_c0`
- Replaces NADP<sup>+</sup> (`cpd00006_c0`) and NADPH (`cpd00005_c0`) with NAD<sup>+</sup> (`cpd00003_c0`) and NADH (`cpd00004_c0`) in `rxn21863_c0`
- Changes the ID of `rxn21859_c0` to `rxn46124_c0`
- Changes the ID of `rxn21863_c0` to `rxn45550_c0`

`WP_049586958.1` was annotated with the E.C. numbers for NAD-dependent reduction of (2E)-enoyl-ACPs and (2E)-enoyl-CoAs to acyl-ACPs and acyl-CoAs, and all but two of the reactions that it is currently associated with fall into one of those two categories. There don’t seem to be any genes annotated with the E.C. numbers for NADP-dependent reduction of (2E)-enoyl-ACPs, and ModelSEED has NAD-dependent versions of both reactions.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists