### PR TITLE
Fix: GPR of rxn05039

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #302** (CUSTOM-CI)
+- **PR #307** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Adds new gene yigB (`WP_049587094.1`) to the model
- Changes the GPR of `rxn05039_c0` from `WP_049588741.1` to `WP_049587094.1`

`WP_049588741.1` is currently in the GPRs of both `rxn00980_c0` and `rxn05039_c0`, but was only annotated with the E.C. number for `rxn00980_c0` (3.1.3.18). eggNOG annotated `WP_049587094.1` with the E.C. number for `rxn05039_c0` (3.1.3.104). I noticed this because `rxn05039_c0` is not currently in the HOT1A3 or ATCC27126 models, and I wanted to make sure it belonged in the MIT1002 model before I tried looking for genes in the other two strains that encode an enzyme that could catalyze it.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists