### PR TITLE
fix: remove H+ from rxn05301

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #306** (CUSTOM-CI)
+- **PR #308** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:
<!-- Try to be as clear as possible in providing a summary of the work and reference the corresponding issue.
Is it fixing/adding something in the model?
Is it an additional test/function/dataset? 
e.g. This PR improves/fixes # by ...
-->
In double checking the changes in #281, I noticed that `rxn05301_c0` still involved H+ (`cpd00067`). 

The notes in #281 said that the PR "Replaces H+ (`cpd00067`) with Na+ (`cpd00971`) in `rxn05301_c0` (symport with tyrosine)", and other reactions with that same note no longer have H+ at all in their reactions. 

E.g. the reaction for the improved homoserine transport (`rxn05684_c0`), is:
`cpd00227_c0 + cpd00971_c0 <=> cpd00227_e0 + cpd00971_e0` or
"L-Homoserine + Na+ <=> L-Homoserine [e0] + Na+ [e0]"

But the reaction for tyrosine (`rxn05301_c0`) is:
`2.0 cpd00067_e0 + cpd00069_e0 + cpd00971_e0 <=> 2.0 cpd00067_c0 + cpd00069_c0 + cpd00971_c0` or
"2.0 H+ [e0] + L-Tyrosine [e0] + Na+ [e0] <=> 2.0 H+ + L-Tyrosine + Na+"

So I:
* Removed H+ from `rxn05301_c0`
* Changed the name of `rxn05301_c0` from "L-Tyrosine:proton symport" to "L-Tyrosine:Na+ symport"

**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [x] Made my edits to the model on the XML file
- [x] Tested my code on my own computer for running the model
- [x] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
