### PR TITLE
fix: remove rxn10481, WP_049587504.1 & WP_012516907.1

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #312** (CUSTOM-CI)
+- **PR #313** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request removes `rxn10481_c0`, `WP_049587504.1`, and `WP_012516907.1`, which I thought I did but apparently forgot in #303.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists