### PR TITLE
Fix: remove genes with no annotated enzymatic activities along with associated reactions & metabolites

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #313** (CUSTOM-CI)
+- **PR #315** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Adds new gene `WP_231514338.1` to the model
- Changes the GPRs of `rxn00452_c0` and `rxn08703_c0` from `WP_049585628.1` to `WP_231514338.1`
- Removes `rxn01203_c0`: 2,4-Dihydroxyhept-2-enedioate --> Pyruvate + 4-Oxobutanoate, GPR: `WP_049588784.1`
- Removes `rxn09022_c0`: 2 O16 antigen undecaprenyl diphosphate <=> Bactoprenyl diphosphate + (O16 antigen)x2 undecaprenyl diphosphate, GPR: `WP_049587197.1`
- Removes lipoteichoic acid biosynthesis reactions `rxn10192_c0`, `rxn10289_c0`, `rxn10290_c0`, `rxn10291_c0`, `rxn10292_c0`, `rxn10293_c0`, `rxn10294_c0`, `rxn10295_c0`, `rxn10296_c0`, and `rxn10297_c0` from the model (all have GPR `WP_080986386.1`)
- Removes lipoteichoic acid biosynthesis reactions `rxn10307_c0`, `rxn10308_c0`, `rxn10309_c0`, `rxn10312_c0`, `rxn10313_c0`, `rxn10314_c0`, and `rxn10315_c0` from the model (all have GPR `WP_014948529.1`)
- Removes 2,4-Dihydroxyhept-2-enedioate (`cpd03708_c0` ) from the model
- Removes (O16 antigen)x2 undecaprenyl diphosphate (`cpd15516_c0`) from the model
- Removes O16 antigen undecaprenyl diphosphate (`cpd15520_c0`) from the model
- Removes glycolipid metabolites `cpd02967_c0`, `cpd15728_c0`, `cpd15729_c0`, `cpd15730_c0`, `cpd15731_c0`, `cpd15732_c0`, `cpd15733_c0`, `cpd15734_c0`, `cpd15735_c0`, and `cpd15736_c0` from the model
- Removes lipoteichoic acid metabolites `cpd15561_c0`, `cpd15746_c0`, `cpd15747_c0`, `cpd15748_c0`, `cpd15749_c0`, `cpd15750_c0`, `cpd15751_c0`, `cpd15752_c0`, `cpd15753_c0`, `cpd15754_c0`, `cpd15764_c0`, `cpd15765_c0`, `cpd15766_c0`, `cpd15769_c0`, `cpd15770_c0`, `cpd15771_c0`, and `cpd15772_c0` from the model
- Removes genes `WP_049585628.1`, `WP_049588784.1`, `WP_049587197.1` and `WP_080986386.1` from the model

While investigating reactions that were currently in the MIT1002 model but not one or both of the ATCC27126 and HOT1A3 models, I came across several reactions associated with genes that had no annotated enzymatic activities and could find no genes in any strain’s genome annotated with the relevant E.C. numbers for those reactions. The only exceptions were `rxn00452_c0` and `rxn08239_c0`, which can be catalyzed by `WP_231514338.1`. Most of these reactions were the only reactions that one or more of their metabolites participated in, so I’m also removing those metabolites.

I am also removing all but one of the reactions currently associated with `WP_014948529.1`, which was annotated with E.C. 2.7.8.33, which KEGG describes as primarily being responsible for catalyzing `rxn08040_c0` (which already has `WP_014948529.1` in its GPR). KEGG also mentions that it participates in the biosynthesis of teichoic acid in some Gram-positive bacteria, which explains why these reactions got added to the model but wound up isolated, since *Alteromonas macleodii* is Gram-negative (because none of the other genes responsible for the rest of teichoic acid biosynthesis are present).

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists