### PR TITLE
Fix: remove dead-end reactions & metabolites representing physiologically irrelevant promiscuous activities

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #313** (CUSTOM-CI)
+- **PR #316** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Removes `rxn00196_c0`: 2,5-Dioxopentanoate + NADP<sup>+</sup> + H<sub>2</sub>O <=> 2-Oxoglutarate + NADPH + 2 H<sup>+</sup>, GPR: `WP_014950281.1`
- Removes `rxn01032_c0`: Benzaldehyde + NAD<sup>+</sup> + H<sub>2</sub>O <=> Benzoate + NADH + 2 H<sup>+</sup>, GPR: `WP_014950281.1 or WP_049588355.1`
- Removes `rxn01033_c0`: Benzaldehyde + NADP<sup>+</sup> + H<sub>2</sub>O <=> Benzoate + NADPH + 2 H<sup>+</sup>, GPR: `WP_014950281.1 or WP_049585438.1`
- Removes `rxn01729_c0`: 5-Oxopentanoate + NAD<sup>+</sup> + H<sub>2</sub>O <=> Glutarate + NADH + 2 H<sup>+</sup> GPR: `WP_014950281.1 or WP_049588355.1`
- Removes `rxn08703_c0`: Homocysteine + S-Methyl-L-methionine <=> 2.0 L-Methionine + H<sup>+</sup>, GPR: `WP_231514338.1`
- Removes `rxn24668_c0`: 5-Oxopentanoate + NADP<sup>+</sup> + H<sub>2</sub>O <=> Glutarate + NADPH + 2 H<sup>+</sup>, GPR: `WP_014950281.1 or WP_049585438.1`
- Removes `rxn37372_c0`: 2,5-Dioxopentanoate + NAD<sup>+</sup> + H<sub>2</sub>O <=> 2-Oxoglutarate + NADH + 2 H<sup>+</sup>, GPR: `WP_014950281.1 or WP_049588355.1`
- Removes metabolite `cpd00225_c0` (Benzaldehyde) from the model
- Removes metabolite `cpd00340_c0` (2,5-Dioxopentanoate) from the model
- Removes metabolite `cpd00379_c0` (Glutarate)
- Removes metabolite `cpd02027_c0` (S-Methylmethionine) from the model

While looking into reactions that are in this model but not the ATCC27126 or HOT1A3 models, I noticed that several of the MIT1002-only reactions were dead-end reactions that only got added because of promiscuous enzymes. For instance, `WP_231514338.1` was annotated with E.C. 2.1.1.10, which [KEGG](https://www.genome.jp/entry/2.1.1.10) says “uses S-adenosylmethionine as methyl donor less actively than S-methylmethionine”, but that isn’t actually evidence of an enzyme that can produce S-methylmethionine (`rxn00452_c0` uses S-adenosylmethionine instead of S-methylmethionine and is otherwise identical to `rxn08703_c0`). Similarly, the genes in the GPRs of the other reactions that this PR removes all encode aldehyde/carboxylate oxidoreductases with broad substrate specificity, but only some of those substrates can actually be produced or consumed by other enzymes that we have evidence to believe are actually present in this particular strain.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists