### PR TITLE
Fix: connect dead-end metabolite lactaldehyde

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #313** (CUSTOM-CI)
+- **PR #317** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request adds `rxn15341_c0`: L-Lactaldehyde + NAD<sup>+</sup> <=> 2-Oxopropanal + NADH + H<sup>+</sup>, GPR: `WP_049587342.1 or WP_049586860.1` and makes no other changes to the model.

L-Lactaldehyde (`cpd00334_c0`) is currently a dead-end, as it can only participate in `rxn01053_c0`. As mentioned in #285, `WP_049587342.1` and `WP_049586860.1` were annotated as alcohol dehydrogenases with particularly broad substrate specificities, so they could almost certainly oxidize lactaldehyde to 2-oxopropanal (`cpd00428_c0`), which already participates in several other reactions in the model. 

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists