### PR TITLE
Fix: Miscellaneous GPR errors found while comparing to other strains

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #317** (CUSTOM-CI)
+- **PR #318** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Changes the GPR of `rxn11732_c0` from `WP_049587342.1 or WP_049586860.1 or WP_049586860.1` to `WP_049587342.1 or WP_049586860.1 or WP_049586233.1`
- Changes the GPR of `rxn29147_c0` from `WP_049586048.1 and WP_012516834.1 and WP_049587498.1 and WP_049586047.1` to `(WP_049586048.1 or WP_012516834.1) and (WP_049587498.1 or WP_049586047.1)`

While comparing annotations of homologous genes between the MIT1002, ATCC27126, and HOT1A3 strains, I noticed that `WP_049586048.1` and `WP_012516834.1` have the same annotations, and should be treated as isozymes (and ditto for `WP_049587498.1` and `WP_049586047.1`). I also noticed that I accidentally repeated `WP_049586860.1` in the GPR of `rxn11732_c0` when I changed it in #285 — I meant to include `WP_049586233.1` as a third isozyme in that GPR.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists