### PR TITLE
Fix: Strict ATP production

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #328** (CUSTOM-CI)
+- **PR #329** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:
<!-- Try to be as clear as possible in providing a summary of the work and reference the corresponding issue.
Is it fixing/adding something in the model?
Is it an additional test/function/dataset? 
e.g. This PR improves/fixes # by ...
-->
This pull request makes several reactions that involve ATP irreversible, only allowing flux in the ATP-consuming direction. The reactions are also listed in [this comment](https://github.com/C-CoMP-STC/GEM-mit1002/issues/296#issuecomment-3534368566). This PR closes #296:
* Makes `rxn00077_c0` (ATP + NAD <=> NADP + ADP + H+) irreversible (sets the LB to 0)
* Makes `rxn00104_c0` (ATP + PPi + H+ <=> ADP + Triphosphate) irreversible (sets the LB to 0)
* Makes `rxn00239_c0` (ATP + H+ + GMP <=> ADP + GDP) irreversible (sets the LB to 0)
* Makes `rxn00364_c0 ` (ATP + CMP + H+ <=> ADP + CDP) irreversible (sets the LB to 0)
* Makes `rxn00379_c0` (ATP + Sulfate <=> PPi + 5'-Adenylyl sulfate [c0]) irreversible (sets the LB to 0)
* Makes `rxn01219_c0 ` (ATP + H+ + dCMP <=> ADP + dCDP) irreversible (sets the LB to 0)
* Makes `rxn01509_c0` (ATP + H+ + dGMP <=> ADP + dGDP) irreversible (sets the LB to 0)
* Makes `rxn01517_c0` (ATP + H+ + dUMP <=> ADP + dUDP) irreversible (sets the LB to 0)
* Makes `rxn02314_c0` (ATP + D-Tagatose 6-phosphate <=> ADP + H+ + D-Tagatose 1,6-biphosphate) irreversible (sets the LB to 0)
* Makes `rxn08762_c0 ` (H2O + ATP + K+ [e0] <=> ADP + Phosphate + H+ + K+) irreversible (sets the LB to 0)
* Makes `rxn15121_c0 ` (ATP + alpha-D-Galactose <=> ADP + H+ + D-Galactose 1-phosphate) irreversible (sets the LB to 0)

**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [x] Made my edits to the model on the XML file
- [x] Tested my code on my own computer for running the model
- [x] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
