### PR TITLE
Fix: remove unsubstantiated differences from ATCC27126 and HOT1A3 models

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #329** (CUSTOM-CI)
+- **PR #339** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Adds `rxn00629_c0`: D-Mannitol + NAD<sup>+</sup> <-> D-Fructose + NADH + H<sup>+</sup>, GPR: `WP_049589016.1`
- Replaces NADP<sup>+</sup> and NADPH with NAD<sup>+</sup> and NADH in `rxn39452_c0`
- Changes the ID of `rxn39452_c0` to `rxn39451_c0`

`rxn00629_c0` is already in the ATCC27126 and HOT1A3 models, and the genes in those GPRs are the reciprocal best BLAST hits of `WP_049589016.1` and have identical annotations. This reaction might have been missing because ModelSEED seems to have the wrong E.C. number (1.1.1.11 instead of 1.1.1.67), but I’m not sure why that would only have affected the MIT1002 model and not the other two.

The ATCC27126 and HOT1A3 models have `rxn39451_c0` (NAD-dependent) instead of `rxn39452_c0` (NADP-dependent), and the genes in all three GPRs are reciprocal best BLAST hits of each other and all annotated with E.C. 1.17.1.8, which does not specify if the enzyme is NAD-dependent, NADP-dependent, or capable of using both.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [X] Tested my code on my own computer for running the model
- [X] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists