### PR TITLE
fix: remove duplicate pyks

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #340** (CUSTOM-CI)
+- **PR #341** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:
<!-- Try to be as clear as possible in providing a summary of the work and reference the corresponding issue.
Is it fixing/adding something in the model?
Is it an additional test/function/dataset? 
e.g. This PR improves/fixes # by ...
-->
To avoid loops, I think it is best to keep only one reaction for pyruvate kinase (PEP + NDP --> Pyruvate + NTP). Because all of the reactions currently in the model were associated with the same gene pyk/`WP_014949855.1`, I do not think there is actually evidence that there are this many different enzymes. To resolve this, this PR:
* Removes `rxn00304_c0` (GDP-dependent)
* Removes `rxn00411_c0` (CDP-dependent)
* Removes `rxn00460_c0` (UDP-dependent)
* Removes `rxn00840_c0` (dADP-dependent)
* Removes `rxn01354_c0` (dGDP-dependent)

Closes #332

**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [x] Made my edits to the model on the XML file
- [x] Tested my code on my own computer for running the model
- [x] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
