### PR TITLE
Fix: Coefficient of biomass pseudometabolite

### DIFF
--- a/biomass/rebalance_biomass_stoich.py
+++ b/biomass/rebalance_biomass_stoich.py
@@ -13,15 +13,23 @@ weight = calculate_biomass_weight(
 )
 
 # Rebalance the reaction stoichiometry
+# NOTE: This also changes the coefficient of the biomass pseudometabolite,
+# which it should NOT, that should be left as 1
+# For now, I will just leave it like this, but you do need to go change just
+# that coefficient back to 1 manually after running this script
+# If we need to run this script multiple times, we should add code to reset
+# the biomass pseudometabolite coefficient to 1 after rebalancing
 if weight != 1.000:
-    print(f"Biomass weight is {weight} g/mol, rebalancing biomass reaction stoichiometry")
+    print(
+        f"Biomass weight is {weight} g/mol, rebalancing biomass reaction stoichiometry"
+    )
     biomass_reaction = model.reactions.get_by_id("bio1_biomass")
     biomass_reaction.add_metabolites(
         {
             met: coef * (1 / weight)
             for met, coef in biomass_reaction.metabolites.items()
         },
-        combine=False
+        combine=False,
     )
 
 # Save the updated model

--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #360** (CUSTOM-CI)
+- **PR #363** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:
<!-- Try to be as clear as possible in providing a summary of the work and reference the corresponding issue.
Is it fixing/adding something in the model?
Is it an additional test/function/dataset? 
e.g. This PR improves/fixes # by ...
-->
* Changes the stoichiometric coefficeint for the biomass pseudometatbolite (`cpd11416_c0`) in the biomass reaction (`bio1_biomass`) to 1.0 (from 1.34)


**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [x] Made my edits to the model on the XML file
- [x] Tested my code on my own computer for running the model
- [x] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
