### PR TITLE
feat: add the basal media name to the error message table

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #364** (CUSTOM-CI)
+- **PR #365** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.

--- a/test/test_growth.py
+++ b/test/test_growth.py
@@ -101,14 +101,14 @@ class TestGrowthPhenotypes(unittest.TestCase):
                 "\nPredicted growth phenotypes do not match experimental data for the following conditions:"
             ]
             # Add a header for the output table
-            header = f"{'Carbon Source':<25} | {'Experimental':<12} | {'Predicted':<12} | {'Ex Rxn Present':<10}"
+            header = f"{'Media':<35} | {'Carbon Source':<25} | {'Experimental':<12} | {'Predicted':<12} | {'Ex Rxn Present':<10}"
             error_message.append(header)
             error_message.append("-" * len(header))
 
             # Add a row for each mismatch
             for index, row in mismatches.iterrows():
                 # Note: Assuming you have a 'c_source' column as in your original file
-                line = f"{row['c_source']:<25} | {row['growth']:<12} | {row['pred_growth']:<12} | {row['all_ex_rxn_present']:<10}"
+                line = f"{row['minimal_media']:<35} | {row['c_source']:<25} | {row['growth']:<12} | {row['pred_growth']:<12} | {row['all_ex_rxn_present']:<10}"
                 error_message.append(line)
 
             # Combine the list into a single string and fail the test


### PR DESCRIPTION
#### Main improvements in this PR:
<!-- Try to be as clear as possible in providing a summary of the work and reference the corresponding issue.
Is it fixing/adding something in the model?
Is it an additional test/function/dataset? 
e.g. This PR improves/fixes # by ...
-->
* Adds the basal medium name to the error message of `test_expected_growth_phenotypes`

But does not change the model itself, see #320 for details.


**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [ ] Made my edits to the model on the XML file
- [x] Tested my code on my own computer for running the model
- [x] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
