### PR TITLE
fix: change bd to bo in rxn14422 name

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #382** (CUSTOM-CI)
+- **PR #385** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:
<!-- Try to be as clear as possible in providing a summary of the work and reference the corresponding issue.
Is it fixing/adding something in the model?
Is it an additional test/function/dataset? 
e.g. This PR improves/fixes # by ...
-->
* Changes the name of `rxn14422_c0` from "cytochrome-bd oxidase (2 protons translocated) [c0]", as it is [in the ModelSEED database](https://modelseed.org/biochem/reactions/rxn14422), to "cytochrome-bo oxidase (2 protons translocated) [c0]", to reflect the cytochrome actually used in the reaction: `0.5 O2 + 4.0 H+ + Cytochrome-bo-red --> H2O + 2.0 H+ [e0] + Cytochrome-bo-ox`


**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [x] Made my edits to the model on the XML file
- [x] Tested my code on my own computer for running the model
- [x] Selected `dev` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
