### PR TITLE
Fix diel cycle COMETS simulation

### DIFF
--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -2,6 +2,6 @@
 
 The results shown here were obtained by the GitHub Actions run in:
 
-- **PR #401** (CUSTOM-CI)
+- **PR #402** (CUSTOM-CI)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.

--- a/simulations/comets_diel_cycle/run_comets_diel_cycle.py
+++ b/simulations/comets_diel_cycle/run_comets_diel_cycle.py
@@ -1,12 +1,17 @@
+#!/Users/helenscott/opt/miniconda3/envs/med4-hot1a3/bin/python
 import math
+import os
 
+import cometspy as c
 import matplotlib.pyplot as plt
 
-import comets as c
+os.environ["COMETS_HOME"] = "/Applications/COMETS"
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 # Load Prochlorococcus Genome-scale model
-model = c.model("iSO595v6.xml")
-model.initial_pop = [1, 1, 1e-7]
+model = c.model(os.path.join(SCRIPT_DIR, "iSO595v6.xml"))
+model.initial_pop = [0, 0, 1e-7]
 model.obj_style = "MAX_OBJECTIVE_MIN_TOTAL"
 
 # The ratio of chlorophyll is extracted from the model biomass-function
@@ -88,11 +93,27 @@ sim_params.all_params["maxCycles"] = 480
 sim_params.all_params["timeStep"] = 0.1
 sim_params.all_params["defaultDiffConst"] = 0
 
-# Runs comets and produce the output files mediaLog.m and biomassLog.m
+# Run COMETS simulation
 simulation = c.comets(layout, sim_params)
-simulation.JAVA_CLASSPATH = "/home/djordje/Dropbox/COMETS_RUN/lib/jmatio.jar:/home/djordje/Dropbox/COMETS_RUN/lib/jdistlib-0.4.5-bin.jar:/home/djordje/Dropbox/COMETS_RUN/lib/commons-math3-3.6.1.jar:/home/djordje/Dropbox/COMETS_RUN/lib/commons-lang3-3.9.jar:/home/djordje/Dropbox/COMETS_RUN/lib/colt.jar:/home/djordje/Dropbox/COMETS_RUN/lib/concurrent.jar:/home/djordje/Dropbox/COMETS_RUN/bin/comets_2.8.2.jar:/opt/gurobi901/linux64/lib/gurobi.jar"
 simulation.run(delete_files=False)
 
 print(simulation.run_output)
 
 # Plot results
+fig, axes = plt.subplots(2, 1, figsize=(10, 8), sharex=True)
+
+time_hours = simulation.total_biomass["cycle"] * sim_params.all_params["timeStep"]
+axes[0].plot(time_hours, simulation.total_biomass.iloc[:, 1])
+axes[0].set_ylabel("Biomass (gDW)")
+axes[0].set_title("Prochlorococcus diel cycle simulation")
+
+photon_media = simulation.media[simulation.media["metabolite"] == "Photon[e]"]
+if not photon_media.empty:
+    photon_time = photon_media["cycle"] * sim_params.all_params["timeStep"]
+    axes[1].plot(photon_time, photon_media["conc_mmol"])
+    axes[1].set_ylabel("Photon concentration (mmol)")
+axes[1].set_xlabel("Time (hours)")
+
+plt.tight_layout()
+plt.savefig(os.path.join(SCRIPT_DIR, "diel_cycle_results.png"), dpi=150)
+plt.show()


### PR DESCRIPTION
## Summary

- Switch import from comets to cometspy (local comets/ dir was shadowing the package)
- Replace hardcoded JAVA_CLASSPATH (djordje machine) with COMETS_HOME env var
- Fix initial_pop [1,1,1e-7] to [0,0,1e-7] — default grid is 1x1 so position [1,1] was out of bounds
- Use script-relative path for iSO595v6.xml
- Add biomass and photon plots saved to diel_cycle_results.png

Also patches a bug in cometspy 0.4.18 (med4-hot1a3 env): LIGHT block was written with absolute reaction ID instead of exchange reaction index, causing a Java error.

## To run

Requires a valid Gurobi license, then:

    source /Users/helenscott/opt/miniconda3/etc/profile.d/conda.sh
    conda activate med4-hot1a3
    cd simulations/comets_diel_cycle
    python run_comets_diel_cycle.py

Generated with Claude Code